### PR TITLE
84 terminology

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -213,7 +213,7 @@ For the purposes of this specification, a value as defined by
 {{-json}} is also viewed as a tree of nodes.
 Each node, in turn, holds a value.
 Furthernodes within each value are the elements of Arrays and the
-member values of objects and are themselves Values.
+member values of objects and are themselves values.
 (The type of the value held by a node is
 may also be referred to as the type of the node.)
 
@@ -257,7 +257,7 @@ x['store']['book'][0]['title']
 ~~~~
 
 in popular programming languages such as JavaScript, Python and PHP,
-with a variable x holding the Argument.  Here we observe that
+with a variable x holding the argument.  Here we observe that
 such languages already have a fundamentally XPath-like feature built
 in.
 
@@ -270,9 +270,9 @@ The JSONPath tool in question should:
 
 ## Overview of JSONPath Expressions {#overview}
 
-JSONPath expressions always apply to a Value in the same way
+JSONPath expressions always apply to a value in the same way
 as XPath expressions are used in combination with an XML document.
-Since a Value is anonymous, JSONPath uses the abstract name `$` to
+Since a value is anonymous, JSONPath uses the abstract name `$` to
 refer to the root node of the argument.
 
 JSONPath expressions can use the *dot–notation*
@@ -354,7 +354,7 @@ JSONPath:
 # JSONPath Examples
 
 This section provides some more examples for JSONPath expressions.
-The examples are based on the simple Value shown in
+The examples are based on the simple JSON value shown in
 {{fig-example-value}}, which was patterned after a
 typical XML example representing a bookstore (that also has bicycles).
 
@@ -409,8 +409,8 @@ constant.
 | `//book[position()<3]` | `$..book[0,1]`<br>`$..book[:2]`           | the first two books                                          |
 | `//book[isbn]`         | `$..book[?(@.isbn)]`                      | filter all books with isbn number                            |
 | `//book[price<10]`     | `$..book[?(@.price<10)]`                  | filter all books cheaper than 10                             |
-| `//*`                  | `$..*`                                    | all elements in XML document; all member values and array elements contained in Value |
-{: #tbl-example title="Example JSONPath expressions applied to the example Value"}
+| `//*`                  | `$..*`                                    | all elements in XML document; all member values and array elements contained in input value |
+{: #tbl-example title="Example JSONPath expressions applied to the example JSON value"}
 
 <!-- XXX: fine tune: is $..* really member values + array elements -->
 
@@ -436,8 +436,8 @@ A well-formed JSONPath query is valid if it also fulfills all semantic
 requirements posed by this document.
 
 The well-formedness and the validity of JSONPath queries are independent of
-the Value the query is applied to; no further errors can be
-raised during application of the query to a Value.
+the value the query is applied to; no further errors can be
+raised during application of the query to a value.
 
 (Obviously, an implementation can still fail when executing a JSONPath
 query, e.g., because of resource depletion, but this is not modeled in
@@ -494,7 +494,7 @@ selector or a set of nodes subordinate to that current node.
 ## Syntax
 
 Syntactically, a JSONPath consists of a root selector (`$`), which
-stands for a nodelist that contains the root node of the Argument,
+stands for a nodelist that contains the root node of the argument,
 followed by a possibly empty sequence of *selectors*.
 
 ~~~~ abnf
@@ -530,9 +530,9 @@ For each node in the list, the selector selects zero or more nodes,
 each of which is a descendant of the node or the node itself.
 
 > Discussion (D4): Is that a common requirement?  Or can a selector also go
-> up, or to the query Argument?
+> up, or to the query argument?
 
-For instance, with the Argument `{"a":[{"b":0},{"b":1},{"c":2}]}`, the
+For instance, with the argument `{"a":[{"b":0},{"b":1},{"c":2}]}`, the
 JSONPath `$.a[*].b` selects the following list of nodes: `0`, `1`
 (denoted here by their value).
 Let's walk through this in detail.

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -156,11 +156,21 @@ their UTF-8 encoding.
 For example, the Unicode PLACE OF INTEREST SIGN (U+2318) would be defined
 in ABNF as `%x2318`.
 
-The terminology of {{-json}} applies, including definitions for
-"Value", "Object", "Array", "Number", and "String".
-Additional terms used in this specification are defined below.
+The terminology of {{-json}} applies except where clarified below.
+Definitions for "Object", "Array", and "Number" remain unchanged.
 Importantly "object" and "array" in particular do not take on a
 generic meaning, such as they would in a general programming context.
+
+Additional terms used in this specification are defined below.
+
+String:
+: A sequence of UTF-8 characters surrounded by either single quotes (`)
+  or double quotes (").
+  Escaping quote characters is required only for the specific character
+  which surrounds the string.
+  For example, a double quote character (") within a string surrounded
+  by single quotes (') does not need to be escaped.
+  Single quotes are preferred.
 
 Member:
 : A name/value pair in a JSON object.  (Not itself a value.)
@@ -197,22 +207,20 @@ Nodelist:
   While this list can be represented in JSON, e.g. as an array, the
   Nodelist is an abstract concept unrelated to JSON values.
 
-<!--
-  I feel like the below definition should be for "normalized path,"
-  but maybe that deserves its own section that also declares any
-  location included in the output Nodelist MUST be normalized.
-  (Also see line 291.) Requesting PR comments.
--->
-
-Output Path:
+Normalized Path:
 : A simple form of JSONPath expression that identifies a node by
   providing a query that results in exactly that node.  Similar
   to, but syntactically different from, a JSON Pointer {{-pointer}}.
 
+<!--
+  Depending on the outcome of [?()] expression support discussions,
+  we may also need to define "boolean", "number", and perhaps others.
+-->
+
 For the purposes of this specification, a value as defined by
 {{-json}} is also viewed as a tree of nodes.
 Each node, in turn, holds a value.
-Furthernodes within each value are the elements of Arrays and the
+Further nodes within each value are the elements of arrays and the
 member values of objects and are themselves values.
 (The type of the value held by a node is
 may also be referred to as the type of the node.)
@@ -420,10 +428,10 @@ constant.
 
 ## Overview {#synsem-overview}
 
-A JSONPath is a string which selects zero or more nodes of a piece of JSON.
-A valid JSONPath conforms to the ABNF syntax defined by this document.
+A JSONPath query is a string which selects zero or more nodes of a piece of JSON.
+A valid query conforms to the ABNF syntax defined by this document.
 
-A JSONPath MUST be encoded using UTF-8. To parse a JSONPath according to
+A query MUST be encoded using UTF-8. To parse a JSONPath according to
 the grammar in this document, its UTF-8 form SHOULD first be decoded into
 Unicode code points as described
 in {{RFC3629}}.
@@ -493,7 +501,7 @@ selector or a set of nodes subordinate to that current node.
 
 ## Syntax
 
-Syntactically, a JSONPath consists of a root selector (`$`), which
+Syntactically, a JSONPath query consists of a root selector (`$`), which
 stands for a nodelist that contains the root node of the argument,
 followed by a possibly empty sequence of *selectors*.
 
@@ -507,7 +515,7 @@ The syntax and semantics of each selector is defined below.
 
 ## Semantics
 
-The root selector `$` not only selects the Root node of the argument,
+The root selector `$` not only selects the root node of the argument,
 but it also produces as output a list consisting of one
 node: the argument itself.
 
@@ -533,11 +541,11 @@ each of which is a descendant of the node or the node itself.
 > up, or to the query argument?
 
 For instance, with the argument `{"a":[{"b":0},{"b":1},{"c":2}]}`, the
-JSONPath `$.a[*].b` selects the following list of nodes: `0`, `1`
+query `$.a[*].b` selects the following list of nodes: `0`, `1`
 (denoted here by their value).
 Let's walk through this in detail.
 
-The JSONPath consists of `$` followed by three selectors: `.a`, `[*]`, and `.b`.
+The query consists of `$` followed by three selectors: `.a`, `[*]`, and `.b`.
 
 Firstly, `$` selects the root node which is the argument.
 So the result is a list consisting of just the root node.
@@ -557,7 +565,7 @@ This is the concatenation of three lists, two of length one containing
 `0`, `1`, respectively, and one of length zero.
 
 As a consequence of this approach, if any of the selectors selects no nodes,
-then the whole JSONPath selects no nodes.
+then the whole query selects no nodes.
 
 In what follows, the semantics of each selector are defined for each type
 of node.
@@ -906,7 +914,7 @@ MUST raise an error.
 
 # IANA Considerations {#IANA}
 
-TBD: Define a media type for JSON Path expressions.
+TBD: Define a media type for JSONPath expressions.
 
 # Security Considerations {#Security}
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -163,36 +163,37 @@ Importantly "object" and "array" in particular do not take on a
 generic meaning, such as they would in a general programming context.
 
 Member:
-: A name/value pair in a JSON object.  (Not itself a Value.)
+: A name/value pair in a JSON object.  (Not itself a value.)
 
 Name:
 : The name in a name/value pair constituting a member.  (Also known as
   "key", "tag", or "label".)
+  This is also used in {{-json}}, but that specification does not 
+  formally define it.
+  It is included here for completeness.
 
 Element:
-: A Value in an array.  (Also used with a distinct meaning in XML
+: A value in an array.  (Also used with a distinct meaning in XML
   context for XML elements.)
 
 Index:
 : A non-negative integer that identifies a specific element in an array.
-  The term, in particular in the form indexing, is also sometimes used
-  for either an index or a member name, when both arrays and objects
-  can be fed to the indexing operation.
 
 Query:
 : Short name for JSONPath expression.
 
 Argument:
-: Short name for the Value a JSONPath expression is applied to.
+: Short name for the value a JSONPath expression is applied to.
 
 Node:
-: The pair of a Value along with its location within the Argument.
+: The pair of a value along with its location within the argument.
 
 Root Node:
-: The unique Node whose Value is the entire Argument.
+: The unique node whose value is the entire argument.
 
 Nodelist:
-: Output of applying a query to an Argument, manifested as a list of Nodes.
+: A list of nodes.  <!-- ordered list?  Maybe TBD by issues #27 and #60 -->
+  The output of applying a query to an argument is manifested as a list of nodes.
   While this list can be represented in JSON, e.g. as an array, the
   Nodelist is an abstract concept unrelated to JSON values.
 
@@ -200,7 +201,7 @@ Nodelist:
   I feel like the below definition should be for "normalized path,"
   but maybe that deserves its own section that also declares any
   location included in the output Nodelist MUST be normalized.
-  Requesting PR comments.
+  (Also see line 290.) Requesting PR comments.
 -->
 
 Output Path:
@@ -208,20 +209,15 @@ Output Path:
   providing a query that results in exactly that node.  Similar
   to, but syntactically different from, a JSON Pointer {{-pointer}}.
 
-For the purposes of this specification, a Value as defined by
+For the purposes of this specification, a value as defined by
 {{-json}} is also viewed as a tree of nodes.
-Each node, in turn, holds a Value.
-Further nodes within the Value are the elements of arrays and the
-member values of JSON objects contained in the Value and are
-themselves Values.
-(The type of the Value held by a node is
+Each node, in turn, holds a value.
+Furthernodes within each value are the elements of Arrays and the
+member values of objects and are themselves Values.
+(The type of the value held by a node is
 may also be referred to as the type of the node.)
 
-A JSONPath query is applied to a Value that is supplied to it as
-its Argument.
-The node referring to the entirety of this Value is also
-referred to as its root node.
-
+A query is applied to an argument, and the output is a nodelist.
 
 ## Inspired by XPath
 
@@ -261,7 +257,7 @@ x['store']['book'][0]['title']
 ~~~~
 
 in popular programming languages such as JavaScript, Python and PHP,
-with a variable x holding the Value.  Here we observe that
+with a variable x holding the Argument.  Here we observe that
 such languages already have a fundamentally XPath-like feature built
 in.
 
@@ -277,7 +273,7 @@ The JSONPath tool in question should:
 JSONPath expressions always apply to a Value in the same way
 as XPath expressions are used in combination with an XML document.
 Since a Value is anonymous, JSONPath uses the abstract name `$` to
-refer to the entire Value ("root node") of the argument.
+refer to the root node of the argument.
 
 JSONPath expressions can use the *dot–notation*
 
@@ -459,20 +455,17 @@ the internal workings of an implementation:  Implementations may wish
 conform to the model.
 
 In the processing model,
-a valid JSONPath query is executed against a Value, the *Argument*, and
-produces a list of zero or more nodes of the Value which are
-selected by the JSONPath.
-(Note that the term Value also implies that this value complies
-to the definitions in {{-json}}, i.e., is indeed a Value.)
+a valid query is executed against a value, the *argument*, and
+produces a list of zero or more nodes of the value.
 
-The JSONPath query is a sequence of zero or more *selectors*, each of
+The query is a sequence of zero or more *selectors*, each of
 which is applied to the result of the previous selector and provides
 input to the next selector.
 These results and inputs take the form of a *nodelist*, i.e., a
 sequence of zero or more nodes.
 
 The nodelist going into the first selector contains a single node,
-holding the Argument.
+the argument.
 The nodelist resulting from the last selector is presented as the
 result of the query; depending on the specific API, it might be
 presented as an array of the JSON values at the nodes, an array of
@@ -483,8 +476,8 @@ the result of the query.
 
 A selector performs its function on each of the nodes in its input
 nodelist, during such a function execution, such a node is referred to
-as "current node".  Each of these function executions produces a
-result nodelist, which are then combined by algorithm *combine1* into
+as the "current node".  Each of these function executions produces a
+nodelist, which are then combined by algorithm *combine1* into
 the result of the selector.
 
 > Discussion (D2): We haven't decided yet whether there is only one
@@ -492,7 +485,7 @@ the result of the selector.
 > concatenation with duplicate removal, based on a definition of
 > duplicate, are candidates.
 
-The processing within a selector may execute nested JSONPath queries,
+The processing within a selector may execute nested queries,
 which are in turn handled with the processing model defined here.
 Typically, the argument to that query will be the current node of the
 selector or a set of nodes subordinate to that current node.
@@ -514,9 +507,9 @@ The syntax and semantics of each selector is defined below.
 
 ## Semantics
 
-The root selector `$` not only selects the root node of the input
-document, but it also produces as output a list consisting of one
-node: the input Value.
+The root selector `$` not only selects the Root node of the argument,
+but it also produces as output a list consisting of one
+node: the argument itself.
 
 A selector may select zero or more nodes for further processing.
 A syntactically valid selector MUST NOT produce errors.
@@ -546,7 +539,7 @@ Let's walk through this in detail.
 
 The JSONPath consists of `$` followed by three selectors: `.a`, `[*]`, and `.b`.
 
-Firstly, `$` selects the root node which is the input document.
+Firstly, `$` selects the root node which is the argument.
 So the result is a list consisting of just the root node.
 
 Next, `.a` selects from any input node of type object and selects any value of the input

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -173,7 +173,7 @@ String:
   Single quotes are preferred.
 
 Member:
-: A name/value pair in a JSON object.  (Not itself a value.)
+: A name/value pair in an object.  (Not itself a value.)
 
 Name:
 : The name in a name/value pair constituting a member.  (Also known as

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -186,17 +186,22 @@ Argument:
 : Short name for the Value a JSONPath expression is applied to.
 
 Node:
-: A Value, with an emphasis on its location within the
-  Argument.  I.e., a Value that is identical to or contained within the JSON
-  value to which the query is applied.  A node can be viewed as a
-  combination of a (1) Value and (2) its location in the
-  Argument; the latter can, if desired, be represented as an Output Path.
+: The pair of a Value along with its location within the Argument.
+
+Root Node:
+: The unique Node whose Value is the entire Argument.
 
 Nodelist:
-: Output of applying a query to an argument: a list of nodes within
-  that argument.
+: Output of applying a query to an Argument, manifested as a list of Nodes.
   While this list can be represented in JSON, e.g. as an array, the
-  nodelist is an abstract concept unrelated to JSON values.
+  Nodelist is an abstract concept unrelated to JSON values.
+
+<!--
+  I feel like the below definition should be for "normalized path,"
+  but maybe that deserves its own section that also declares any
+  location included in the output Nodelist MUST be normalized.
+  Requesting PR comments.
+-->
 
 Output Path:
 : A simple form of JSONPath expression that identifies a node by

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -201,7 +201,7 @@ Nodelist:
   I feel like the below definition should be for "normalized path,"
   but maybe that deserves its own section that also declares any
   location included in the output Nodelist MUST be normalized.
-  (Also see line 290.) Requesting PR comments.
+  (Also see line 291.) Requesting PR comments.
 -->
 
 Output Path:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -156,8 +156,9 @@ their UTF-8 encoding.
 For example, the Unicode PLACE OF INTEREST SIGN (U+2318) would be defined
 in ABNF as `%x2318`.
 
-
-The terminology of {{-json}} applies.
+The terminology of {{-json}} applies, including definitions for
+"value", "object", "array", "number", and "string".
+Additional terms used in this specification are defined below.
 
 For the purposes of this specification, a JSON value as defined by
 {{-json}} is also viewed as a tree of nodes.
@@ -173,11 +174,6 @@ its Argument.
 The node referring to the entirety of this JSON value is also
 referred to as its root node.
 
-JSON value:
-: As per {{-json}}, a structure complying to the generic data model of JSON, i.e.,
-  composed of components such as containers, namely JSON objects and arrays, and
-  atomic data, namely null, true, false, numbers, and text strings.
-
 Node:
 : A JSON value, with an emphasis on its location within the
   Argument.  I.e., a JSON value that is identical to or contained within the JSON
@@ -185,20 +181,12 @@ Node:
   combination of a (1) JSON value and (2) its location in the
   Argument; the latter can, if desired, be represented as an Output Path.
 
-Object:
-: A JSON object as defined in {{-json}}.
-  Never used in its generic sense, e.g., for programming language objects.
-
 Member:
 : A name/value pair in a JSON object.  (Not itself a JSON value.)
 
 Name:
 : The name in a name/value pair constituting a member.  (Also known as
   "key", "tag", or "label".)
-
-Array:
-: A JSON array as defined in {{-json}}.
-  Never used in its generic sense, e.g., for programming language objects.
 
 Element:
 : A JSON value in an array.  (Also used with a distinct meaning in XML

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -163,6 +163,11 @@ generic meaning, such as they would in a general programming context.
 
 Additional terms used in this specification are defined below.
 
+Value:
+: As per {{-json}}, a structure complying to the generic data model of JSON, i.e.,
+  composed of components such as containers, namely JSON objects and arrays, and
+  atomic data, namely null, true, false, numbers, and text strings.
+
 String:
 : A sequence of UTF-8 characters surrounded by either single quotes (`)
   or double quotes (").

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -391,7 +391,7 @@ typical XML example representing a bookstore (that also has bicycles).
   }
 }
 ~~~~
-{: #fig-example-value title="Example Value"}
+{: #fig-example-value title="Example JSON value"}
 
 The examples in {{tbl-example}} use the expression mechanism to obtain
 the number of elements in an array, to test for the presence of a

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -157,39 +157,41 @@ For example, the Unicode PLACE OF INTEREST SIGN (U+2318) would be defined
 in ABNF as `%x2318`.
 
 The terminology of {{-json}} applies, including definitions for
-"value", "object", "array", "number", and "string".
+"Value", "Object", "Array", "Number", and "String".
 Additional terms used in this specification are defined below.
+Importantly "object" and "array" in particular do not take on a
+generic meaning, such as they would in a general programming context.
 
-For the purposes of this specification, a JSON value as defined by
+For the purposes of this specification, a Value as defined by
 {{-json}} is also viewed as a tree of nodes.
-Each node holds a JSON value of one of the types defined in {{-json}};
-further nodes within the JSON value are the elements of arrays and the
-member values of JSON objects contained in the JSON value and are
-themselves JSON values of one of the types defined in {{-json}}.
-(The type of the JSON value held by a node is
-sometimes referred to as the type of the node.)
+Each node, in turn, holds a Value.
+Further nodes within the Value are the elements of arrays and the
+member values of JSON objects contained in the Value and are
+themselves Values.
+(The type of the Value held by a node is
+may also be referred to as the type of the node.)
 
-A JSONPath query is applied to a JSON value that is supplied to it as
+A JSONPath query is applied to a Value that is supplied to it as
 its Argument.
-The node referring to the entirety of this JSON value is also
+The node referring to the entirety of this Value is also
 referred to as its root node.
 
 Node:
-: A JSON value, with an emphasis on its location within the
-  Argument.  I.e., a JSON value that is identical to or contained within the JSON
+: A Value, with an emphasis on its location within the
+  Argument.  I.e., a Value that is identical to or contained within the JSON
   value to which the query is applied.  A node can be viewed as a
-  combination of a (1) JSON value and (2) its location in the
+  combination of a (1) Value and (2) its location in the
   Argument; the latter can, if desired, be represented as an Output Path.
 
 Member:
-: A name/value pair in a JSON object.  (Not itself a JSON value.)
+: A name/value pair in a JSON object.  (Not itself a Value.)
 
 Name:
 : The name in a name/value pair constituting a member.  (Also known as
   "key", "tag", or "label".)
 
 Element:
-: A JSON value in an array.  (Also used with a distinct meaning in XML
+: A Value in an array.  (Also used with a distinct meaning in XML
   context for XML elements.)
 
 Index:
@@ -202,7 +204,7 @@ Query:
 : Short name for JSONPath expression.
 
 Argument:
-: Short name for the JSON value a JSONPath expression is applied to.
+: Short name for the Value a JSONPath expression is applied to.
 
 Nodelist:
 : Output of applying a query to an argument: a list of nodes within
@@ -254,7 +256,7 @@ x['store']['book'][0]['title']
 ~~~~
 
 in popular programming languages such as JavaScript, Python and PHP,
-with a variable x holding the JSON value.  Here we observe that
+with a variable x holding the Value.  Here we observe that
 such languages already have a fundamentally XPath-like feature built
 in.
 
@@ -267,10 +269,10 @@ The JSONPath tool in question should:
 
 ## Overview of JSONPath Expressions {#overview}
 
-JSONPath expressions always apply to a JSON value in the same way
+JSONPath expressions always apply to a Value in the same way
 as XPath expressions are used in combination with an XML document.
-Since a JSON value is anonymous, JSONPath uses the abstract name `$` to
-refer to the entire JSON value ("root node") of the argument.
+Since a Value is anonymous, JSONPath uses the abstract name `$` to
+refer to the entire Value ("root node") of the argument.
 
 JSONPath expressions can use the *dot–notation*
 
@@ -351,7 +353,7 @@ JSONPath:
 # JSONPath Examples
 
 This section provides some more examples for JSONPath expressions.
-The examples are based on the simple JSON value shown in
+The examples are based on the simple Value shown in
 {{fig-example-value}}, which was patterned after a
 typical XML example representing a bookstore (that also has bicycles).
 
@@ -388,7 +390,7 @@ typical XML example representing a bookstore (that also has bicycles).
   }
 }
 ~~~~
-{: #fig-example-value title="Example JSON value"}
+{: #fig-example-value title="Example Value"}
 
 The examples in {{tbl-example}} use the expression mechanism to obtain
 the number of elements in an array, to test for the presence of a
@@ -406,8 +408,8 @@ constant.
 | `//book[position()<3]` | `$..book[0,1]`<br>`$..book[:2]`           | the first two books                                          |
 | `//book[isbn]`         | `$..book[?(@.isbn)]`                      | filter all books with isbn number                            |
 | `//book[price<10]`     | `$..book[?(@.price<10)]`                  | filter all books cheaper than 10                             |
-| `//*`                  | `$..*`                                    | all elements in XML document; all member values and array elements contained in JSON value |
-{: #tbl-example title="Example JSONPath expressions applied to the example JSON value"}
+| `//*`                  | `$..*`                                    | all elements in XML document; all member values and array elements contained in Value |
+{: #tbl-example title="Example JSONPath expressions applied to the example Value"}
 
 <!-- XXX: fine tune: is $..* really member values + array elements -->
 
@@ -433,8 +435,8 @@ A well-formed JSONPath query is valid if it also fulfills all semantic
 requirements posed by this document.
 
 The well-formedness and the validity of JSONPath queries are independent of
-the JSON value the query is applied to; no further errors can be
-raised during application of the query to a JSON value.
+the Value the query is applied to; no further errors can be
+raised during application of the query to a Value.
 
 (Obviously, an implementation can still fail when executing a JSONPath
 query, e.g., because of resource depletion, but this is not modeled in
@@ -452,11 +454,11 @@ the internal workings of an implementation:  Implementations may wish
 conform to the model.
 
 In the processing model,
-a valid JSONPath query is executed against a JSON value, the *Argument*, and
-produces a list of zero or more nodes of the JSON value which are
+a valid JSONPath query is executed against a Value, the *Argument*, and
+produces a list of zero or more nodes of the Value which are
 selected by the JSONPath.
-(Note that the term JSON value also implies that this value complies
-to the definitions in {{-json}}, i.e., is indeed a JSON value.)
+(Note that the term Value also implies that this value complies
+to the definitions in {{-json}}, i.e., is indeed a Value.)
 
 The JSONPath query is a sequence of zero or more *selectors*, each of
 which is applied to the result of the previous selector and provides
@@ -509,7 +511,7 @@ The syntax and semantics of each selector is defined below.
 
 The root selector `$` not only selects the root node of the input
 document, but it also produces as output a list consisting of one
-node: the input JSON value.
+node: the input Value.
 
 A selector may select zero or more nodes for further processing.
 A syntactically valid selector MUST NOT produce errors.

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -162,27 +162,6 @@ Additional terms used in this specification are defined below.
 Importantly "object" and "array" in particular do not take on a
 generic meaning, such as they would in a general programming context.
 
-For the purposes of this specification, a Value as defined by
-{{-json}} is also viewed as a tree of nodes.
-Each node, in turn, holds a Value.
-Further nodes within the Value are the elements of arrays and the
-member values of JSON objects contained in the Value and are
-themselves Values.
-(The type of the Value held by a node is
-may also be referred to as the type of the node.)
-
-A JSONPath query is applied to a Value that is supplied to it as
-its Argument.
-The node referring to the entirety of this Value is also
-referred to as its root node.
-
-Node:
-: A Value, with an emphasis on its location within the
-  Argument.  I.e., a Value that is identical to or contained within the JSON
-  value to which the query is applied.  A node can be viewed as a
-  combination of a (1) Value and (2) its location in the
-  Argument; the latter can, if desired, be represented as an Output Path.
-
 Member:
 : A name/value pair in a JSON object.  (Not itself a Value.)
 
@@ -206,6 +185,13 @@ Query:
 Argument:
 : Short name for the Value a JSONPath expression is applied to.
 
+Node:
+: A Value, with an emphasis on its location within the
+  Argument.  I.e., a Value that is identical to or contained within the JSON
+  value to which the query is applied.  A node can be viewed as a
+  combination of a (1) Value and (2) its location in the
+  Argument; the latter can, if desired, be represented as an Output Path.
+
 Nodelist:
 : Output of applying a query to an argument: a list of nodes within
   that argument.
@@ -216,6 +202,20 @@ Output Path:
 : A simple form of JSONPath expression that identifies a node by
   providing a query that results in exactly that node.  Similar
   to, but syntactically different from, a JSON Pointer {{-pointer}}.
+
+For the purposes of this specification, a Value as defined by
+{{-json}} is also viewed as a tree of nodes.
+Each node, in turn, holds a Value.
+Further nodes within the Value are the elements of arrays and the
+member values of JSON objects contained in the Value and are
+themselves Values.
+(The type of the Value held by a node is
+may also be referred to as the type of the node.)
+
+A JSONPath query is applied to a Value that is supplied to it as
+its Argument.
+The node referring to the entirety of this Value is also
+referred to as its root node.
 
 
 ## Inspired by XPath


### PR DESCRIPTION
Resolves #84

## Alterations

- Removed `Object`, and `Array` since they are defined in 8259.  Replaced with extended verbiage at the beginning of the section that declares that 8259 applies.
- Replaced "JSON value" with "value" in line with the above.
- Relabeled "output path" as "normalized path"

## Additions

- String - a clarification and expansion on the JSON definition
- Root Node

## Other

- Reordered terms and paragraphs so that reading through doesn't use terms that haven't been defined yet (as much as possible).
- Removed a redundant parenthetical sentence in the *Processing Model* section.
- Removed some un-necessary self-references (e.g. "JSONPath query" rather than just "query").
- Made some general edits

## Notes

### Existing in-place definitions

"Selector" and "slice" are defined in-place where they're needed.  Do we need to define them in the terminology section as well?

### Key

The draft currently uses "name" instead of "key" as we had agreed in the meeting.  I suspect that this is because 8259 uses "name."  Since we're trying to align with that, I've left in "name."

### Index

We discussed using "index" as a generic term for either a numeric index for arrays or a name for objects.  However in editing this section, I'm starting to second-guess that decision.

Given that we've opted to define a union selector as taking as arguments "indices," "slices," and/or "filters," I don't think it's too much of a stretch to separately include "indices" and "names."  Because of this, I left the definition of "index" as is.

This also addresses the tendency to associate "index" with arrays, as @glyn had mentioned.

I'm leaving the changes to "union selector" to include all of the various things it can accept for another PR as this is solely to clean up terminology.

### Emphasizing terms

I tried capitalizing defined terms to emphasize their special meaning.  It got weird to read, though, since they're used so frequently.  Maybe not _every_ instance of the terms needs to be emphasized.  I'm not sure.  Happy to discuss.

I've left this change out for now, but there are definitely inconsistencies present already.
