### PR TITLE
Fix invalid link

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -171,7 +171,7 @@ in ABNF as `%x2318`.
 
 The terminology of {{-json}} applies except where clarified below.
 The terms "Primitive" and "Structured" are used to group
-the types as in {{Section 1 of -json}}.
+the types as in Section 1 of {{-json}}.
 Definitions for "Object", "Array", "Number", and "String" remain
 unchanged.
 Importantly "object" and "array" in particular do not take on a


### PR DESCRIPTION
Without this `make` fails with:

draft-ietf-jsonpath-base.xml(0): Error: IDREF attribute target references an unknown ID "_json", at None