### PR TITLE
Break ABNF syntax

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -484,7 +484,7 @@ stands for a nodelist that contains the root node of the argument,
 followed by a possibly empty sequence of *selectors*.
 
 ~~~~ abnf
-json-path = root-selector *(S (dot-selector        /
+json-path == root-selector *(S (dot-selector        /
                                dot-wild-selector   /
                                index-selector      /
                                index-wild-selector /


### PR DESCRIPTION
scripts/gen.sh fails with:

...
stdin(0:12): error: state 19, token $end: syntax error, unexpected '='
parsing failed: 1 errors encountered

and returns a non-zero exit status code.