### PR TITLE
Normalized Paths and how JSONPath relates to JSON Pointer

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1109,8 +1109,8 @@ Single quotes are used to delimit string member names. This reduces the number o
 need escaping when Normalized Paths appear as strings (which are delimited with double quotes) in JSON documents.
 
 The syntax of Normalized Paths is restricted so that there is one and only one way of representing any
-given Normalized Path. Putting this another way, for any two distinct Normalized Paths, there is a JSON document
-which will yield distinct results when the Normalized Paths are applied to the document.
+given Normalized Path. Putting this another way, for any two distinct Normalized Paths, a JSON document exists
+which will yield distinct results when the Normalized Paths are applied to the it.
 
 Certain characters are escaped in one and only one way; all other characters are unescaped.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1110,9 +1110,9 @@ need escaping when Normalized Paths appear as strings (which are delimited with 
 
 The syntax of Normalized Paths is restricted so that there is one and only one way of representing any
 given Normalized Path. Putting this another way, for any two distinct Normalized Paths, a JSON document exists
-which will yield distinct results when the Normalized Paths are applied to the it.
+which will yield distinct results when the Normalized Paths are applied to it.
 
-Certain characters are escaped in one and only one way; all other characters are unescaped.
+Certain characters are escaped, in one and only one way; all other characters are unescaped.
 
 ~~~~ abnf
 normalized-path           = root-selector *(normal-index-selector)

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1102,8 +1102,7 @@ the JSONPath expression `$.book[?(@.price<10)]` could select two values with Nor
 `$['book'][3]` and `$['book'][5]`. For a given JSON document, there is a one to one correspondence between the document's
 nodes and the Normalized Paths that identify these nodes.
 
-An example application of Normalized Paths is a JSONPath implementation which outputs Normalized Paths
-instead of, or in addition to, the values identified by these paths.
+A JSONPath implementation may output Normalized Paths instead of, or in addition to, the values identified by these paths.
 
 Since bracket notation is more general than dot notation, it is used to construct Normalized Paths.
 Single quotes are used to delimit string member names. This reduces the number of characters that


### PR DESCRIPTION
Specify Normalized Paths
    
Also clarify the relationship of JSONPath in general, and Normalized Paths in particular, to JSON Pointer.
    
The approach for Normal Paths is to minimise escaping. The alternative of maximising escaping was rejected because the results are unreadable. The alternative of escaping all but a particular set of characters was rejected because it would be biassed.
    
Co-authored-by: @cabo 

Fixes https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/67