### PR TITLE
Inline examples (batch 1)

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1015,6 +1015,23 @@ When `step = 0`, no elements are selected and the result array is empty.
 To be valid, the slice expression parameters MUST be in the I-JSON
 range of exact values, see {{synsem-overview}}.
 
+#### Examples
+{: unnumbered}
+
+JSON document:
+
+    ["a", "b", "c", "d", "e", "f", "g"]
+
+Queries:
+
+| Query | Result | Result Paths | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$[1:3]` | `"b"` <br> `"c"` | `$[1]` <br> `$[2]` | Slice with default step |
+| `$[1:5:2]` | `"b"` <br> `"d"` | `$[1]` <br> `$[3]` | Slice with step 2 |
+| `$[5:1:-2]` | `"f"` <br> `"d"` | `$[5]` <br> `$[3]` | Slice with negative step |
+| `$[::-1]` | `"g"` <br> `"f"` <br> `"e"` <br> `"d"` <br> `"c"` <br> `"b"` <br> `"a"` | `$[6]` <br> `$[5]` <br> `$[4]` <br> `$[3]` <br> `$[2]` <br> `$[1]` <br> `$[0]` | Slice in reverse order |
+{: title="Array slice selector examples"}
+
 ### Descendant Selector
 
 #### Syntax

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1060,6 +1060,28 @@ In the resultant nodelist:
 
 Children of an object may occur in any order, since JSON objects are unordered.
 
+#### Examples
+{: unnumbered}
+
+JSON document:
+
+    {
+      o: {"j": 1, "k": 2},
+      a: [5, 3]
+    }
+
+Queries:
+
+| Query | Result | Result Paths | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$..j` | `1` | `$['o']['j']` | Object values      |
+| `$..[0]` | `5` | `$['a'][0]` | Array values |
+| `$..[*]` | `{"j": 1, "k" : 2}` <br> `[5, 3]` <br> `1` <br> `2` <br> `5` <br> `3` | `$['0']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]`   | All values     |
+| `$..*` | `{"j": 1, "k" : 2}` <br> `[5, 3]` <br> `1` <br> `2` <br> `5` <br> `3` | `$['0']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]`     | All values    |
+{: title="Descendant selector examples"}
+
+Note: This ordering of the results for the `$..[*]` and `$..*` examples above is not guaranteed, except that `5` must appear before `3`.
+
 ### Filter Selector
 
 #### Syntax

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -756,26 +756,6 @@ Notes:
 2. An `element-index` is an integer (in base 10, as in JSON numbers).
 3. As in JSON numbers, the syntax does not allow octal-like integers with leading zeros such as `01` or `-01`.
 
-#### Examples
-{: unnumbered}
-
-JSON document:
-
-    {
-      o: {"j j": {"k.k": 3}},
-      a: ["a","b"]
-    }
-
-Queries:
-
-| Query | Result | Result Paths | Comment |
-| :---: | ------ | :----------: | ------- |
-| `$.o['j j']['k.k']`   | `3` | `$['o']['j ']['k.k']`      | Named value in nested object      |
-| `$.o["j j"]["k.k"]`   | `3` | `$['o']['j ']['k.k']`      | Named value in nested object      |
-| `$.a[1]`   | `"b"` | `$['a'][1]`      | Member of array      |
-| `$.a[-2]`   | `"a"` | `$['a'][0]`      | Member of array, from the end      |
-{: title="Index selector examples"}
-
 #### Semantics {#index-semantics}
 {: unnumbered}
 
@@ -810,6 +790,25 @@ For example, selector `[-1]` selects the last and selector `[-2]` selects the pe
 As with non-negative indexes, it is not an error if such an element does
 not exist; this simply means that no element is selected.
 
+#### Examples
+{: unnumbered}
+
+JSON document:
+
+    {
+      o: {"j j": {"k.k": 3}},
+      a: ["a","b"]
+    }
+
+Queries:
+
+| Query | Result | Result Paths | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$.o['j j']['k.k']`   | `3` | `$['o']['j ']['k.k']`      | Named value in nested object      |
+| `$.o["j j"]["k.k"]`   | `3` | `$['o']['j ']['k.k']`      | Named value in nested object      |
+| `$.a[1]`   | `"b"` | `$['a'][1]`      | Member of array      |
+| `$.a[-2]`   | `"a"` | `$['a'][0]`      | Member of array, from the end      |
+{: title="Index selector examples"}
 
 ### Index Wildcard Selector
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1076,11 +1076,16 @@ Queries:
 | :---: | ------ | :----------: | ------- |
 | `$..j` | `1` | `$['o']['j']` | Object values      |
 | `$..[0]` | `5` | `$['a'][0]` | Array values |
-| `$..[*]` | `{"j": 1, "k" : 2}` <br> `[5, 3]` <br> `1` <br> `2` <br> `5` <br> `3` | `$['0']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]`   | All values     |
-| `$..*` | `{"j": 1, "k" : 2}` <br> `[5, 3]` <br> `1` <br> `2` <br> `5` <br> `3` | `$['0']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]`     | All values    |
+| `$..[*]` | `{o: {"j": 1, "k": 2}, a: [5, 3]}` <br> `{"j": 1, "k" : 2}` <br> `[5, 3]` <br> `1` <br> `2` <br> `5` <br> `3` | `$['0']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]`   | All values     |
+| `$..*` | `{o: {"j": 1, "k": 2}, a: [5, 3]}` <br> `{"j": 1, "k" : 2}` <br> `[5, 3]` <br> `1` <br> `2` <br> `5` <br> `3` | `$['0']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]`     | All values    |
 {: title="Descendant selector examples"}
 
-Note: This ordering of the results for the `$..[*]` and `$..*` examples above is not guaranteed, except that `5` must appear before `3`.
+Note: This ordering of the results for the `$..[*]` and `$..*` examples above is not guaranteed, except that:
+
+* `{o: {"j": 1, "k": 2}, a: [5, 3]}` must appear before `{"j": 1, "k": 2}` and `[5, 3]`,
+* `{"j": 1, "k": 2}` must appear before `1` and `2`,
+* `[5, 3]` must appear before `5` and `3`, and
+* `5` must appear before `3`.
 
 ### Filter Selector
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -579,9 +579,15 @@ addressed by the root selector `$`.
 #### Examples
 {: unnumbered}
 
-| JSON | Query | Result | Result Paths | Comment |
-| ---- | :---: | ------ | :----------: | ------- |
-| `{"k": "v"}` | `$` | `{"k": "v"}` | `$` | Root node, regardless of JSON  |
+JSON document:
+
+    {"k": "v"}
+
+Queries:
+
+| Query | Result | Result Path | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$` | `{"k": "v"}` | `$` | Root node |
 {: title="Root selector examples"}
 
 ### Dot Selector
@@ -619,10 +625,16 @@ to the member name from any JSON object in its input nodelist. It selects no nod
 #### Examples
 {: unnumbered}
 
-| JSON | Query | Result | Result Paths | Comment |
-| ---- | :---: | ------ | :----------: | ------- |
-| `{"j": {"k": 3}}` | `$.j`   | `{"k": 3}` | `$['j']`      | Named value of an object      |
-|                   | `$.j.k` | `3`        | `$['j']['k']` | Named value in nested object  |
+JSON document:
+
+    {"j": {"k": 3}}
+
+Queries:
+
+| Query | Result | Result Paths | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$.j`   | `{"k": 3}` | `$['j']`      | Named value of an object      |
+| `$.j.k` | `3`        | `$['j']['k']` | Named value in nested object  |
 {: title="Dot selector examples"}
 
 ### Dot Wildcard Selector {#wildcard}
@@ -649,11 +661,20 @@ string, or true/false/null) selects no node.
 #### Examples
 {: unnumbered}
 
-| JSON | Query | Result | Result Paths | Comment |
-| ---- | :---: | ------ | :----------: | ------- |
-| `{"j": 1, "k": 2}` | `$.*` | `1` <br> `2` | `$['j']` <br> `$['k']` | Object values      |
-|                    | `$.*` | `2` <br> `1` | `$['k']` <br> `$['j']` | Alternative result |
-| `[5, 3]`           | `$.*` | `5` <br> `3` | `$[0]` <br> `$[1]`     | Array members      |
+JSON document:
+
+    {
+      o: {"j": 1, "k": 2},
+      a: [5, 3]
+    }
+
+Queries:
+
+| Query | Result | Result Paths | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$.o.*` | `1` <br> `2` | `$['o']['j']` <br> `$['o']['k']` | Object values      |
+| `$.o.*` | `2` <br> `1` | `$['o']['k']` <br> `$['o']['j']` | Alternative result |
+| `$.a.*` | `5` <br> `3` | `$['a'][0]` <br> `$['a'][1]`     | Array members      |
 {: title="Dot wildcard selector examples"}
 
 ### Index Selector
@@ -738,14 +759,22 @@ Notes:
 #### Examples
 {: unnumbered}
 
-| JSON | Query | Result | Result Paths | Comment |
-| ---- | :---: | ------ | :----------: | ------- |
-| `{"j j": {"k.k": 3}}` | `$['j j']['k.k']`   | `3` | `$['j ']['k.k']`      | Named value in nested object      |
-| `{"j j": {"k.k": 3}}` | `$["j j"]["k.k"]`   | `3` | `$['j ']['k.k']`      | Named value in nested object      |
-| `["a","b"]` | `$[1]`   | `"b"` | `$[1]`      | Member of array      |
-| `["a","b"]` | `$[-2]`   | `"a"` | `$[0]`      | Member of array, from the end      |
-{: title="Index selector examples"}
+JSON document:
 
+    {
+      o: {"j j": {"k.k": 3}},
+      a: ["a","b"]
+    }
+
+Queries:
+
+| Query | Result | Result Paths | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$.o['j j']['k.k']`   | `3` | `$['o']['j ']['k.k']`      | Named value in nested object      |
+| `$.o["j j"]["k.k"]`   | `3` | `$['o']['j ']['k.k']`      | Named value in nested object      |
+| `$.a[1]`   | `"b"` | `$['a'][1]`      | Member of array      |
+| `$.a[-2]`   | `"a"` | `$['a'][0]`      | Member of array, from the end      |
+{: title="Index selector examples"}
 
 #### Semantics {#index-semantics}
 {: unnumbered}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -579,9 +579,9 @@ addressed by the root selector `$`.
 #### Examples
 {: unnumbered}
 
-| JSON | Query | Result | Comment|
-| ---- | :---: | :---:  | ---    |
-| `{"k": "v"}` | `$` | `$` | Root node, regardless of JSON  |
+| JSON | Query | Result | Result Paths | Comment |
+| ---- | :---: | ------ | :----------: | ------- |
+| `{"k": "v"}` | `$` | `{"k": "v"}` | `$` | Root node, regardless of JSON  |
 {: title="Root selector examples"}
 
 ### Dot Selector
@@ -616,6 +616,15 @@ characters — MUST NOT be used with the `dot-selector`.
 The `dot-selector` selects the node of the member value corresponding
 to the member name from any JSON object in its input nodelist. It selects no nodes from any other JSON value.
 
+#### Examples
+{: unnumbered}
+
+| JSON | Query | Result | Result Paths | Comment |
+| ---- | :---: | ------ | :----------: | ------- |
+| `{"j": {"k": 3}}` | `$.j`   | `{"k": 3}` | `$['j']`      | Named value of an object      |
+|                   | `$.j.k` | `3`        | `$['j']['k']` | Named value in nested object  |
+{: title="Dot selector examples"}
+
 ### Dot Wildcard Selector {#wildcard}
 
 #### Syntax
@@ -640,11 +649,11 @@ string, or true/false/null) selects no node.
 #### Examples
 {: unnumbered}
 
-| JSON | Query | Result | Comment|
-| ---- | :---: | :---:  | ---    |
-| `{"j": 1, "k": 2}` | `$.*` | `$['j']` <br> `$['k']` | Object values      |
-|                    | `$.*` | `$['k']` <br> `$['j']` | Alternative result |
-| `[5, 3]`           | `$.*` | `$[0]` <br> `$[1]`     | Array members      |
+| JSON | Query | Result | Result Paths | Comment |
+| ---- | :---: | ------ | :----------: | ------- |
+| `{"j": 1, "k": 2}` | `$.*` | `1` <br> `2` | `$['j']` <br> `$['k']` | Object values      |
+|                    | `$.*` | `2` <br> `1` | `$['k']` <br> `$['j']` | Alternative result |
+| `[5, 3]`           | `$.*` | `5` <br> `3` | `$[0]` <br> `$[1]`     | Array members      |
 {: title="Dot wildcard selector examples"}
 
 ### Index Selector

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -735,6 +735,18 @@ Notes:
 2. An `element-index` is an integer (in base 10, as in JSON numbers).
 3. As in JSON numbers, the syntax does not allow octal-like integers with leading zeros such as `01` or `-01`.
 
+#### Examples
+{: unnumbered}
+
+| JSON | Query | Result | Result Paths | Comment |
+| ---- | :---: | ------ | :----------: | ------- |
+| `{"j j": {"k.k": 3}}` | `$['j j']['k.k']`   | `3` | `$['j ']['k.k']`      | Named value in nested object      |
+| `{"j j": {"k.k": 3}}` | `$["j j"]["k.k"]`   | `3` | `$['j ']['k.k']`      | Named value in nested object      |
+| `["a","b"]` | `$[1]`   | `"b"` | `$[1]`      | Member of array      |
+| `["a","b"]` | `$[-2]`   | `"a"` | `$[0]`      | Member of array, from the end      |
+{: title="Index selector examples"}
+
+
 #### Semantics {#index-semantics}
 {: unnumbered}
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -576,6 +576,13 @@ root-selector  = "$"
 The Argument — the root JSON value — becomes the root node, which is
 addressed by the root selector `$`.
 
+#### Examples
+{: unnumbered}
+
+| JSON | Query | Result | Comment|
+| ---- | :---: | :---:  | ---    |
+| `{"k": "v"}` | `$` | `$` | Root node, regardless of JSON  |
+{: title="Root selector examples"}
 
 ### Dot Selector
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -547,10 +547,10 @@ A JSONPath query consists of a sequence of selectors. Valid selectors are
 
   * Root selector `$` (used at the start of a query and in expressions)
   * Dot selector `.<name>`, used with object member names exclusively.
-  * Dot wild card selector `.*`.
+  * Dot wildcard selector `.*`.
   * Index selector `[<index>]`, where `<index>` is either a (possibly
     negative, see {{index-semantics}}) array index or an object member name.
-  * Index wild card selector `[*]`.
+  * Index wildcard selector `[*]`.
   * Array slice selector `[<start>:<end>:<step>]`, where the optional
     values `<start>`, `<end>`, and `<step>` are integer literals.
   * Nested descendants selector `..`.
@@ -621,7 +621,7 @@ to the member name from any JSON object in its input nodelist. It selects no nod
 #### Syntax
 {: unnumbered}
 
-The dot wild card selector has the form `.*` as defined in the
+The dot wildcard selector has the form `.*` as defined in the
 following syntax:
 
 ~~~~ abnf
@@ -631,12 +631,21 @@ dot-wild-selector    = "." "*"            ;  dot followed by asterisk
 #### Semantics
 {: unnumbered}
 
-A `dot-wild-selector` acts as a wild card by selecting the nodes of
+A `dot-wild-selector` acts as a wildcard by selecting the nodes of
 all member values of an object in its input nodelist as well as all
 element nodes of an array in its input nodelist.
 Applying the `dot-wild-selector` to a primitive JSON value (number,
 string, or true/false/null) selects no node.
 
+#### Examples
+{: unnumbered}
+
+| JSON | Query | Result | Comment|
+| ---- | :---: | :---:  | ---    |
+| `{"j": 1, "k": 2}` | `$.*` | `$['j']` <br> `$['k']` | Object values      |
+|                    | `$.*` | `$['k']` <br> `$['j']` | Alternative result |
+| `[5, 3]`           | `$.*` | `$[0]` <br> `$[1]`     | Array members      |
+{: title="Dot wildcard selector examples"}
 
 ### Index Selector
 
@@ -757,7 +766,7 @@ not exist; this simply means that no element is selected.
 #### Syntax
 {: unnumbered}
 
-The index wild card selector has the form `[*]`.
+The index wildcard selector has the form `[*]`.
 
 ~~~~ abnf
 index-wild-selector    = "[" "*" "]"  ;  asterisk enclosed by brackets
@@ -945,7 +954,7 @@ range of exact values, see {{synsem-overview}}.
 
 The descendant selector starts with a double dot `..` and can be
 followed by an object member name (similar to the `dot-selector`),
-by an `index-selector` acting on objects or arrays, or by a wild card.
+by an `index-selector` acting on objects or arrays, or by a wildcard.
 
 ~~~~ abnf
 descendant-selector = ".." ( dot-member-name      /  ; ..<name>

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -832,6 +832,25 @@ a number, string, or true/false/null) selects no node.
 
 The `index-wild-selector` behaves identically to the `dot-wild-selector`.
 
+#### Examples
+{: unnumbered}
+
+JSON document:
+
+    {
+      o: {"j": 1, "k": 2},
+      a: [5, 3]
+    }
+
+Queries:
+
+| Query | Result | Result Paths | Comment |
+| :---: | ------ | :----------: | ------- |
+| `$.o.[*]` | `1` <br> `2` | `$['o']['j']` <br> `$['o']['k']` | Object values      |
+| `$.o.[*]` | `2` <br> `1` | `$['o']['k']` <br> `$['o']['j']` | Alternative result |
+| `$.a.[*]` | `5` <br> `3` | `$['a'][0]` <br> `$['a'][1]`     | Array members      |
+{: title="Index wildcard selector examples"}
+
 ### Array Slice Selector {#slice}
 
 #### Syntax


### PR DESCRIPTION
Let's use this PR to hash out the formatting preferences. We can come back and tweak later, but please suggest any changes now before I replicate this format in other sections.

See the [rendered HTML](https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/inline-examples-root/draft-ietf-jsonpath-base.html#name-root-selector) and the [rendered plain text](https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/inline-examples-root/draft-ietf-jsonpath-base.txt).

Ref: https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/136