### PR TITLE
String matching is codepoint by codepoint, no normalization

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -555,6 +555,14 @@ A JSONPath query consists of a sequence of selectors. Valid selectors are
   * Filter selector `[?(<expr>)]`
   * Current item selector `@` (used in expressions)
 
+Note that processing the dot selector and string-valued index selectors
+requires matching strings from the JSONPath against member names and
+string values from the JSON to which it is being applied.  Two strings
+MUST be considered equal if and only if they are identical sequences
+of Unicode code points. In other words, normalization operations MUST
+NOT be applied to either the string from the JSONPath or from the JSON
+prior to comparison.
+
 ### Root Selector
 
 #### Syntax

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -555,12 +555,13 @@ A JSONPath query consists of a sequence of selectors. Valid selectors are
   * Filter selector `[?(<expr>)]`
   * Current item selector `@` (used in expressions)
 
-Note that processing the dot selector and string-valued index selectors
-requires matching strings from the JSONPath against member names and
-string values from the JSON to which it is being applied.  Two strings
-MUST be considered equal if and only if they are identical sequences
-of Unicode code points. In other words, normalization operations MUST
-NOT be applied to either the string from the JSONPath or from the JSON
+Note that processing the dot selector, string-valued index selector,
+and filter selector all potentially require matching strings against
+strings, with those strings coming from the JSONPath and from member
+names and string values in the JSON to which it is being applied.
+Two strings MUST be considered equal if and only if they are identical
+sequences of Unicode code points. In other words, normalization operations
+MUST NOT be applied to either the string from the JSONPath or from the JSON
 prior to comparison.
 
 ### Root Selector


### PR DESCRIPTION
Per discussion at recent interim.