### PR TITLE
Follow on to PR 214

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1235,10 +1235,9 @@ the comparison is between numeric values which satisfy the comparison.
 of the same values using the operator `==`, `<=`, `>=`, respectively.
 
 * data types are not implicitly converted in comparisons.
-So, for example, `13 == '13'` yields false.
 
-Note that `==` comparisons between structured values, even if the values are equal, yield false.
-Also `!=` comparisons between structured values, even if the values are equal, yield true.
+Note that `==` comparisons between a structured value and any value, including the same structured value, yield false.
+Also `!=` comparisons between a structured value and any value, including the same structured value, yield true.
 <!-- issue: comparison with structured value -->
 
 ##### Regular Expressions

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1238,7 +1238,7 @@ the comparison is between numeric values which satisfy the comparison.
 of the same values using the operator `==`, `<=`, `>=`, respectively.
 
 Note that `==` comparisons between a structured value and any value, including the same structured value, yield false.
-Consequently `!=` comparisons between a structured value and any value, including the same structured value, yield true.
+Consequently, `!=` comparisons between a structured value and any value, including the same structured value, yield true.
 <!-- issue: comparison with structured value -->
 
 ###### Examples

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1207,8 +1207,11 @@ This existence test — as an exception to the general rule — also works with 
 To make use of the JSON value of a node selected by a path, explicit comparisons are necessary.
 
 When a path resulting in an empty nodelist appears on either side of a comparison, the comparison yields
-true if and only if the comparison operator is `==`, `>=` or `<=` and the other side of the comparison is also a path
-resulting in an empty nodelist.
+true if and only if:
+
+* the comparison operator is `==`, `>=` or `<=` and the other side of the comparison is also a path
+resulting in an empty nodelist, or
+* the comparison operator is `!=` and the other side of the comparison is not also a path resulting in an empty nodelist.
 
 When no path resulting in an empty nodelist appears on either side of a comparison, any path which appears on either
 side of the comparison and results in a nodelist consisting of a single node is replaced by the value of the node

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1208,12 +1208,9 @@ filter selector iterates over the array or object.
 A singular path by itself in a Boolean context is an existence test which yields true if the path selects a node and yields false if the path does not select a node.
 This existence test — as an exception to the general rule — also works with nodes with structured values.
 
-A non-existence test (`!` followed by a singular path by itself, e.g. `!@.foo`) yields true if and only if the corresponding existence test with the same path yields true.
-In other words, a non-existence test yields true if the path does not select a node and yields false if the path selects a node.
-
 To test the value of a node selected by a path, an explicit comparison is necessary.
 For example, to test whether the node selected by the path `@.foo` has the value `null`, use `@.foo == null` (see {{null-semantics}})
-rather than the non-existence test `!@.foo` (which yields false if `@.foo` selects a node, regardless of the node's value).
+rather than the negated existence test `!@.foo` (which yields false if `@.foo` selects a node, regardless of the node's value).
 
 ##### Comparisons
 {: unnumbered}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1204,7 +1204,9 @@ filter selector iterates over the array or object.
 
 A singular path by itself in a Boolean context is an existence test which yields true if the path selects a node and yields false if the path does not select a node.
 This existence test — as an exception to the general rule — also works with nodes with structured values.
-To make use of the JSON value of a node selected by a path, explicit comparisons are necessary.
+To test the value of a node selected by a path, an explicit comparison is necessary.
+For example, to test whether the node selected by the path `@.foo` has the value `null`, use `@.foo == null` (see {{null-semantics}})
+rather than the non-existence test `!@.foo` (which yields false if `@.foo` selects a node, regardless of the node's value).
 
 When a path resulting in an empty nodelist appears on either side of a comparison, the comparison yields
 true if and only if:
@@ -1349,7 +1351,7 @@ Queries:
 | `$[0, 0]` | `"a"` <br> `"a"` | `$[0]` <br> `$[0]` | Duplicated entries |
 {: title="List selector examples"}
 
-## Semantics of `null`
+## Semantics of `null` {#null-semantics}
 
 Note that JSON `null` is treated the same as any other JSON value: it is not taken to mean "undefined" or "missing".
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1203,7 +1203,8 @@ A relative path, beginning with `@`, refers to the current array element or memb
 filter selector iterates over the array or object.
 
 A singular path by itself in a Boolean context is an existence test which yields true if the path selects a node and yields false if the path does not select a node.
-To be more specific about the actual value of a node selected by a path, explicit comparisons are necessary. This existence test — as an exception to the general rule — also works with nodes with structured values.
+This existence test — as an exception to the general rule — also works with nodes with structured values.
+To make use of the JSON value of a node selected by a path, explicit comparisons are necessary.
 
 When a path resulting in an empty nodelist appears on either side of a comparison, the comparison yields
 true if and only if the comparison operator is `==`, `>=` or `<=` and the other side of the comparison is also a path

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1238,7 +1238,7 @@ the comparison is between numeric values which satisfy the comparison.
 of the same values using the operator `==`, `<=`, `>=`, respectively.
 
 Note that `==` comparisons between a structured value and any value, including the same structured value, yield false.
-Also `!=` comparisons between a structured value and any value, including the same structured value, yield true.
+Consequently `!=` comparisons between a structured value and any value, including the same structured value, yield true.
 <!-- issue: comparison with structured value -->
 
 ###### Examples

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1240,6 +1240,40 @@ Note that `==` comparisons between a structured value and any value, including t
 Also `!=` comparisons between a structured value and any value, including the same structured value, yield true.
 <!-- issue: comparison with structured value -->
 
+###### Examples
+{: unnumbered}
+
+JSON:
+
+
+    {
+      "struct": {"x": "y"},
+      "arr": [2, 3]
+    }
+
+| Comparison | Result | Comment |
+|:--:|:--:|:--:|
+| `$.nosuch1 == $.nosuch2` | true | Empty nodelists |
+| `$.nosuch1 == 'g'` | false | Empty nodelist |
+| `$.nosuch1 != $.nosuch2` | false | Empty nodelists |
+| `$.nosuch1 != 'g'` | true | Empty nodelist |
+| `1 <= 2` | true | Numeric comparison |
+| `1 > 2` | false | Strict, numeric comparison |
+| `13 == '13'` | false | No implicit type conversions |
+| `'a' <= 'b'` | false | Non-numeric comparison |
+| `'a' > 'b'` | true | Strict, non-numeric comparison |
+| `$.struct == $.struct` | false | Structured values |
+| `$.struct != $.struct` | true | Structured values |
+| `$.struct == 17` | false | Structured value |
+| `$.struct != 17` | true | Structured value |
+| `$.struct <= $.arr` | false | Structured values |
+| `$.struct < $.arr` | false | Strict comparison, structured values |
+| `1 <= $.arr` | false | Structured value |
+| `1 >= $.arr` | false | Sructured value |
+| `1 > $.arr` | true | Strict comparison, structured value |
+| `1 < $.arr` | true | Strict comparison, structured value |
+{: title="Comparison examples" }
+
 ##### Regular Expressions
 {: unnumbered}
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1202,11 +1202,21 @@ The `filter-selector` works with arrays and objects exclusively. Its result is a
 A relative path, beginning with `@`, refers to the current array element or member value as the
 filter selector iterates over the array or object.
 
+##### Existence Tests
+{: unnumbered}
+
 A singular path by itself in a Boolean context is an existence test which yields true if the path selects a node and yields false if the path does not select a node.
 This existence test — as an exception to the general rule — also works with nodes with structured values.
+
+A non-existence test (`!` followed by a singular path by itself, e.g. `!@.foo`) yields true if and only if the corresponding existence test with the same path yields true.
+In other words, a non-existence test yields true if the path does not select a node and yields false if the path selects a node.
+
 To test the value of a node selected by a path, an explicit comparison is necessary.
 For example, to test whether the node selected by the path `@.foo` has the value `null`, use `@.foo == null` (see {{null-semantics}})
 rather than the non-existence test `!@.foo` (which yields false if `@.foo` selects a node, regardless of the node's value).
+
+##### Comparisons
+{: unnumbered}
 
 When a path resulting in an empty nodelist appears on either side of a comparison, the comparison yields
 true if and only if:
@@ -1215,28 +1225,35 @@ true if and only if:
 resulting in an empty nodelist, or
 * the comparison operator is `!=` and the other side of the comparison is not also a path resulting in an empty nodelist.
 
-When no path resulting in an empty nodelist appears on either side of a comparison, any path which appears on either
-side of the comparison and results in a nodelist consisting of a single node is replaced by the value of the node
-and then:
+When any path on either side of a comparison results in a nodelist consisting of a single node, each such path is
+replaced by the value of its node and then:
 
-* comparison using one of the operators `==` or `!=` yields true if and only if the comparison
-is between:
-    * primitive values which satisfy the comparison, or
-    * structured values compared using `!=`.
+* comparison using one of the operators `==` yields true if and only if the comparison
+is between equal primitive values.
 
-* comparisons using one of the operators `<`, `<=`, `>`, or `>=` yield true if and only if
+* comparisons using one of the operators `<=` or `>=` yield true if and only if
 the comparison is between numeric values which satisfy the comparison.
 
-Note that comparisons between structured values, even if the values are equal, yield false.
+* any comparison of two values using one of the operators `!=`, `>`, `<` is defined as the negation of the comparison
+of the same values using the operator `==`, `<=`, `>=`, respectively.
+
+* data types are not implicitly converted in comparisons.
+So, for example, `13 == '13'` yields false.
+
+Note that `==` comparisons between structured values, even if the values are equal, yield false.
+Also `!=` comparisons between structured values, even if the values are equal, yield true.
 <!-- issue: comparison with structured value -->
 
-Data types are not implicitly converted in comparisons.
-So `13 == '13'` yields false.
+##### Regular Expressions
+{: unnumbered}
 
 A regular-expression test yields true if and only if the value on the left-hand side of `=~` is a string value and it
 matches the regular expression on the right-hand side according to the semantics of {{-iregexp}}.
 
 The semantics of regular expressions are as defined in {{-iregexp}}.
+
+##### Boolean Operators
+{: unnumbered}
 
 The logical AND, OR, and NOT operators have the normal semantics of Boolean algebra and
 consequently obey these laws (where `P`, `Q`, and `R` are any expressions with syntax

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1234,8 +1234,6 @@ the comparison is between numeric values which satisfy the comparison.
 * any comparison of two values using one of the operators `!=`, `>`, `<` is defined as the negation of the comparison
 of the same values using the operator `==`, `<=`, `>=`, respectively.
 
-* data types are not implicitly converted in comparisons.
-
 Note that `==` comparisons between a structured value and any value, including the same structured value, yield false.
 Also `!=` comparisons between a structured value and any value, including the same structured value, yield true.
 <!-- issue: comparison with structured value -->
@@ -1259,7 +1257,7 @@ JSON:
 | `$.nosuch1 != 'g'` | true | Empty nodelist |
 | `1 <= 2` | true | Numeric comparison |
 | `1 > 2` | false | Strict, numeric comparison |
-| `13 == '13'` | false | No implicit type conversions |
+| `13 == '13'` | false | Type mismatch |
 | `'a' <= 'b'` | false | Non-numeric comparison |
 | `'a' > 'b'` | true | Strict, non-numeric comparison |
 | `$.struct == $.struct` | false | Structured values |

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -172,6 +172,9 @@ Value:
   primitive data, namely numbers and text strings as well as the special
   values null, true, and false.
 
+Type:
+: As per {{-json}}, one of the six JSON types (strings, numbers, booleans, null, objects, arrays).
+
 Member:
 : A name/value pair in an object.  (Not itself a value.)
 


### PR DESCRIPTION
* Editorial improvements
* Correct != comparison involving at least one empty nodelist.