### PR TITLE
Delete confusing language about Normalized Paths

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1477,10 +1477,6 @@ Since bracket notation is more general than dot notation, it is used to construc
 Single quotes are used to delimit string member names. This reduces the number of characters that
 need escaping when Normalized Paths appear as strings (which are delimited with double quotes) in JSON texts.
 
-The syntax of Normalized Paths is restricted so that there is one and only one way of representing any
-given Normalized Path. Putting this another way, for any two distinct Normalized Paths, a JSON value exists
-that will yield distinct results when the Normalized Paths are applied to it.
-
 Certain characters are escaped, in one and only one way; all other characters are unescaped.
 
 Normalized Paths are Singular Paths. Not all Singular Paths are Normalized Paths: `$[-3]`, for example, is a Singular


### PR DESCRIPTION
The one to one correspondence sentence gives us most of the desired
properties. The fact that for distinct Normalized Paths there will always
be at least one JSON value which can distinguish the paths is interesting
but not crucial. If it's confusing to some people, then it's probably
a distraction.