### PR TITLE
Ordering of descendant segment with multiple selectors

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1377,7 +1377,6 @@ Note that `D1` is the input value.
 
 For each `i` such that `1 <= i <= n`, the nodelist `Ri` is defined to be a result of applying
 the child segment `[<selectors>]` to the node `Di`.
-Note that `Ri` is the concatenation of the nodelists from each of the selectors.
 
 The result of the descendant selector is the concatenation of `R1`, ..., `Rn` (in that order).
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1376,7 +1376,7 @@ Suppose the nodes, in the order visited, are `D1`, ..., `Dn` (where `n >= 1`).
 Note that `D1` is the input value.
 
 For each `i` such that `1 <= i <= n`, the nodelist `Ri` is defined to be a result of applying
-the child segment `[<selectors>]` (with all its selectors) to the node `Di`.
+the child segment `[<selectors>]` to the node `Di`.
 Note that `Ri` is the concatenation of the nodelists from each of the selectors.
 
 The result of the descendant selector is the concatenation of `R1`, ..., `Rn` (in that order).

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1363,20 +1363,24 @@ Note that `..` on its own is not a valid segment.
 
 A descendant segment produces zero or more descendants of the input value.
 
-A descendant selector of the form `..[<selectors>]` visits each node of the input value and
-its descendants in such an order that:
+A descendant selector visits the input value and each of
+its descendants such that:
 
 * nodes of any array are visited in array order, and
-* nodes are visited before all their descendants.
+* nodes are visited before their descendants.
 
-It applies the child segment `[<selectors>]` to each node and concatenates the resultant nodelists together
-in the order in which the nodes were visited.
-
-This definition does not stipulate the order in which the children of an object are visited, since
+The order in which the children of an object are visited is not stipulated, since
 JSON objects are unordered.
 
-Where a selector can produce a nodelist in more than one possible order, the selector may produce nodelists in distinct
-orders each time it appears in the descendant segment.
+Suppose the nodes, in the order visited, are `D1`, ..., `Dn` (where `n >= 1`).
+Note that `D1` is the input value.
+
+For each `i` such that `1 <= i <= n`, the nodelist `Ri` is defined to be a result of applying
+the child segment `[<selectors>]` (with all its selectors) to the node `Di`.
+Note that `Ri` is the concatenation of the nodelists from each of the selectors.
+
+The result of the descendant selector is the concatenation of `R1`, ..., `Rn` (in that order).
+Note that only a single traversal of the input value and its descendants is required.
 
 So a descendant segment drills down one or more levels into the structure of the input value.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1380,7 +1380,6 @@ the child segment `[<selectors>]` (with all its selectors) to the node `Di`.
 Note that `Ri` is the concatenation of the nodelists from each of the selectors.
 
 The result of the descendant selector is the concatenation of `R1`, ..., `Rn` (in that order).
-Note that only a single traversal of the input value and its descendants is required.
 
 So a descendant segment drills down one or more levels into the structure of the input value.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1387,7 +1387,7 @@ JSON:
 
     {
       "o": {"j": 1, "k": 2},
-      "a": [5, 3, [{"j": 4}]]
+      "a": [5, 3, [{"j": 4}, {"k": 6}]]
     }
 
 Queries:
@@ -1398,22 +1398,28 @@ Queries:
 | `$..j`   | `4` <br> `1` | `$['a'][2][0]['j']` <br> `$['o']['j']` | Alternative result |
 | `$..[0]` | `5` <br> `{"j": 4}` | `$['a'][0]` <br> `$['a'][2][0]` | Array values       |
 | `$..[0]` | `{"j": 4}` <br> `5` | `$['a'][2][0]` <br> `$['a'][0]` | Alternative result |
-| `$..[*]` <br> `$..*` | `{"j": 1, "k" : 2}` <br> `[5, 3, [{"j": 4}]]` <br> `1` <br> `2` <br> `5` <br> `3` <br> `[{"j": 4}]` <br> `{"j": 4}` <br> `4` | `$['o']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]` <br> `$['a'][2]` <br> `$['a'][2][0]` <br> `$['a'][2][0]['j']` | All values    |
+| `$..[*]` <br> `$..*` | `{"j": 1, "k" : 2}` <br> `[5, 3, [{"j": 4}, {"k": 6}]]` <br> `1` <br> `2` <br> `5` <br> `3` <br> `[{"j": 4}, {"k": 6}]` <br> `{"j": 4}` <br> `4` <br> `{"k": 6}` <br> `6` | `$['o']` <br> `$['a']` <br> `$['o']['j']` <br> `$['o']['k']` <br> `$['a'][0]` <br> `$['a'][1]` <br> `$['a'][2]` <br> `$['a'][2][0]` <br> `$['a'][2][0]['j']` <br> `$['a'][2][1]` <br> `$['a'][2][1]['k']` | All values    |
 | `$..o`   | `{"j": 1, "k": 2}` | `$['o']` | Input value is visited |
 | `$.o..[*, *]` | `1` <br> `2` <br> `2` <br> `1` | `$['o']['j']` <br> `$['o']['k']` <br> `$['o']['k']` <br> `$['o']['j']` | Non-deterministic ordering |
+| `$.a..[0, 1]`| `5` <br> `3` <br> `{"j": 4}` <br> `{"k": 6}` | `$['a'][0]` <br> `$['a'][1]` <br> `$['a'][0][2][0]` <br> `$['a'][0][2][1]` | Multiple segments |
 {: title="Descendant segment examples"}
 
 Note: The ordering of the results for the `$..[*]` and `$..*` examples above is not guaranteed, except that:
 
 * `{"j": 1, "k": 2}` must appear before `1` and `2`,
-* `[5, 3, [{"j": 4}]]` must appear before `5`, `3`, and `[{"j": 4}]`,
-* `5` must appear before `3` which must appear before `[{"j": 4}]`,
-* `5` and `3` must appear before `{"j": 4}` and `4`,
-* `[{"j": 4}]` must appear before `{"j": 4}`, and
-* `{"j": 4}` must appear before `4`.
+* `[5, 3, [{"j": 4}, {"k": 6}]]` must appear before `5`, `3`, and `[{"j": 4}, {"k": 6}]`,
+* `5` must appear before `3` which must appear before `[{"j": 4}, {"k": 6}]`,
+* `5` and `3` must appear before `{"j": 4}`, `4`, `, {"k": 6}`, and `6`,
+* `[{"j": 4}, {"k": 6}]` must appear before `{"j": 4}` and `{"k": 6}`,
+* `{"j": 4}` must appear before `4`, and
+* `{"k": 6}` must appear before `6`.
 
 The example above with the query `$.o..[*, *]` shows that a selector may produce nodelists in distinct orders
 each time it appears in the descendant segment.
+
+The example above with the query `$.a..[0, 1]` shows that the child segment `[0, 1]` is applied to each node
+in turn (rather than the nodes being visited once per selector, which is the case for some JSONPath implementations
+that do not conform to this specification).
 
 ## Semantics of `null` {#null-semantics}
 


### PR DESCRIPTION
Give an example to emphasise the spec behaviour. At the time of writing, this disagrees with the implementation consensus here:

https://cburgmer.github.io/json-path-comparison/results/union_with_keys_after_recursive_descent.html

Fixes https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/265