### PR TITLE
Delete confusing statement

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -223,8 +223,7 @@ Root Node:
 
 Children (of a node):
 : If the node is an array, the nodes of its elements.
-  If the node is an object, the nodes of its member values (but not its
-  member names).
+  If the node is an object, the nodes of its member values.
   If the node is neither an array nor an object, it has no children.
 
 Descendants (of a node):

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -225,6 +225,8 @@ Children (of a node):
 : If the node is an array, the nodes of its elements.
   If the node is an object, the nodes of its member values.
   If the node is neither an array nor an object, it has no children.
+  Note that the member names of an object are not values and do not
+  have nodes.
 
 Descendants (of a node):
 : The children of the node, together with the children of its children, and so forth


### PR DESCRIPTION
The deleted statement might be understood to mean that member names have nodes. But it's explicitly stated that member names are not values (and therefore they do not have nodes).

An alternative solution would be to qualify the deleted statement as follows, but this is very clunky in context:

> (but not its member names, which are not values and which do not have nodes)