### PR TITLE
Introduction tweaks

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -259,6 +259,8 @@ Selector:
 
 ## History
 
+This section is informative.
+
 This document picks up {{{Stefan Gössner}}}'s popular JSONPath proposal
 dated 2007-02-21 {{JSONPath-orig}}, builds on the experience from the widespread
 deployment of its implementations, and provides a normative definition for it.
@@ -283,6 +285,8 @@ long as that does not jeopardize the objective of obtaining a usable,
 stable JSON query language.
 
 ## Overview of JSONPath Expressions {#overview}
+
+This section is informative.
 
 A JSONPath expression is applied to a JSON value, the *argument*.
 The output is a nodelist.
@@ -357,9 +361,10 @@ $.store.book[?@.price < 10].title
 | `?<expr>`           | [filter selector](#filter-selector): selects particular children using a boolean expression                             |
 {: #tbl-overview title="Overview of JSONPath"}
 
-# JSONPath Examples
+## JSONPath Examples
 
-This section provides examples of JSONPath expressions.
+This section is informative. It provides examples of JSONPath expressions.
+
 The examples are based on the simple JSON value shown in
 {{fig-example-value}}, representing a bookstore (that also has a bicycle).
 


### PR DESCRIPTION
Move the initial examples into the introduction since the purpose of the examples is introductory.

Mark certain sections as informative (rather than normative).