### PR TITLE
Avoid use of the term key

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1460,7 +1460,7 @@ Queries:
 | `$.b[?@]` | `null` | `$['b'][0]` | Existence |
 | `$.b[?@==null]` | `null` | `$['b'][0]` | Comparison |
 | `$.c[?(@.d==null)]` | | | Comparison with "missing" value |
-| `$.null` | `1` | `$['null']` | Not JSON null at all, just a string as object key |
+| `$.null` | `1` | `$['null']` | Not JSON null at all, just a name string |
 {: title="Examples involving (or not involving) null"}
 
 ## Normalized Paths


### PR DESCRIPTION
This follows on from https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/pull/298 which deleted "key" and other synonyms of "name".