### PR TITLE
Mention JSONPath expressions before query term

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -150,7 +150,7 @@ from a JSON value.
 
 JSON {{-json}} is a popular representation
 format for structured data values.
-JSONPath defines a string syntax for selecting and extracting JSON values
+JSONPath defines string expressions for selecting and extracting JSON values
 from a JSON value.
 
 JSONPath is not intended as a replacement for, but as a more powerful


### PR DESCRIPTION
The definition of a query as a short name for a JSONPath expression then makes more sense.