### PR TITLE
Promote function extensions

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1213,6 +1213,9 @@ Filter selectors may use function extensions, which are covered in Section {{<fn
 #### Examples
 {: unnumbered}
 
+The first set of examples shows some comparison expressions and their
+result with a given JSON value as input.
+
 JSON:
 
     {
@@ -1252,6 +1255,12 @@ JSON:
 | `true > true` | false | Booleans are not ordered |
 {: title="Comparison examples" }
 
+The second set of examples shows some complete JSONPath queries that make use
+of filter selectors, and the results of evaluating these queries on a
+given JSON value as input.
+(Note that two of the queries employ function extensions; please see
+Sections {{<match}} and {{<search}} below for details about these.)
+
 JSON:
 
     {
@@ -1260,8 +1269,6 @@ JSON:
       "o": {"p": 1, "q": 2, "r": 3, "s": 5, "t": {"u": 6}},
       "e": "f"
     }
-
-Queries:
 
 | Query | Result | Result Paths | Comment |
 | :---: | ------ | :----------: | ------- |

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1204,6 +1204,11 @@ compared is an object, array, boolean, or `null`.
 The logical AND, OR, and NOT operators have the normal semantics of Boolean algebra and
 obey its laws (see, for example, {{BOOLEAN-LAWS}}).
 
+##### Function Extensions
+{: unnumbered}
+
+Filter selectors may use function extensions, which are covered in Section {{<fnex}}.
+
 #### Examples
 {: unnumbered}
 
@@ -1277,18 +1282,7 @@ Queries:
 The example above with the query `$.a[?@.b, ?@.b]` shows that the filter selector may produce nodelists in distinct
 orders each time it appears in the child segment.
 
-##### Function Extensions {#fnex}
-{: unnumbered}
-
-[^unnumbered-bad]
-
-[^unnumbered-bad]: This should not be an unnumbered section, which it is
-    forced to be by the parent section being unnumbered too.
-    The overall structure where the parts of this subsection go to
-    needs to be decided; one part already is in the IANA
-    Considerations in {{iana-fnex}}.
-    This PR will focus on content, a future PR will fix the structure.
-{:source=" -- cabo"}
+## Function Extensions {#fnex}
 
 Beyond the filter expression functionality defined in the preceding
 subsections, JSONPath defines an extension point that can be used to
@@ -1320,8 +1314,7 @@ singular-path can occur (exist-expr, comparable).
 A function-expression that employs a function extension that returns a
 nodelist MUST return a singular node to be used in a comparable.
 
-###### Function Extensions: length {#length}
-{: unnumbered}
+### `length` Function Extension {#length}
 
 Arguments:
 : 1. value
@@ -1350,8 +1343,7 @@ integer.
 * For any other argument value, the result is one.
 
 
-###### Function Extensions: count {#count}
-{: unnumbered}
+### `count` Function Extension {#count}
 
 Arguments:
 : 1. nodelist
@@ -1375,8 +1367,7 @@ Note that there is no deduplication of the nodelist. [^dedup]
 [^dedup]: Well, that can be discussed.
 
 
-###### Function Extensions: match {#match}
-{: unnumbered}
+### `match` Function Extension {#match}
 
 Arguments:
 : 1. value (string)
@@ -1399,8 +1390,7 @@ The result is `true` if the string matches the iregexp and `false`
 otherwise.
 
 
-###### Function Extensions: search {#search}
-{: unnumbered}
+### `search` Function Extension {#search}
 
 Arguments:
 : 1. value (string)
@@ -1421,8 +1411,6 @@ Its first argument is a string that is searched for at least one
 substring that matches the iregexp contained in the string
 that is the second argument.
 The result is `true` if such a substring exists, `false` otherwise.
-
-o o o o o o o o o o o o o o o o o o o o o o o o o o o o o o o o
 
 ## Segments  {#segments-details}
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -415,6 +415,7 @@ $.store.book[?@.price < 10].title
 | `3`                 | [index selector](#index-selector): selects an indexed child of an array (from 0)                                        |
 | `0:100:5`           | [array slice selector](#slice): start:end:step for arrays                                                               |
 | `?<expr>`           | [filter selector](#filter-selector): selects particular children using a boolean expression                             |
+| `length(@.foo)`     | [function extension](#fnex): invokes a function in a filter expression                                                  |
 {: #tbl-overview title="Overview of JSONPath"}
 
 ## JSONPath Examples


### PR DESCRIPTION
... so that they appear in the table of contents. More editorial polishing may be required afterward, but this gets a block move of some examples out of the way while there aren't many other PRs in flight.