### PR TITLE
Close #325

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1464,9 +1464,7 @@ $[?count(@.*.author) >= 5]
 Its only argument is a nodelist.
 The result is a value, an unsigned integer, that gives the number of
 nodes in the nodelist.
-Note that there is no deduplication of the nodelist. [^dedup]
-
-[^dedup]: Well, that can be discussed.
+Note that there is no deduplication of the nodelist.
 
 
 ### `match` Function Extension {#match}


### PR DESCRIPTION
Delete the editor's note as
»Note that there is no deduplication of the nodelist.« is now the agreed behavior.