### PR TITLE
Remove `BooleanType` as a type for consistent expression grammar

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1095,13 +1095,9 @@ filter-selectors enclosing the filter-selector that is directly
 enclosing the identifier).
 
 A test expression either tests the existence of a node
-designated by an embedded query (see {{extest}}) or tests the
-result of a function expression (see {{fnex}}).
-In the latter case, if the function expression is of type
-`ST(OptionalBooleanType)` (see {{typesys}}), it tests whether the result
-is `true`; if the function expression is of type
-`ST(OptionalNodesType)`, it tests whether the result is different from
-`Nothing`.
+designated by an embedded query (see {{extest}}) or function expression
+(see {{fnex}}).  A function is only valid as a test expression if
+it is of the type `ST(OptionalNodesType)`.
 
 ~~~~ abnf
 boolean-expr        = logical-or-expr
@@ -1117,8 +1113,7 @@ basic-expr          = paren-expr /
                       test-expr
 test-expr           = [logical-not-op S]
                       (filter-path / ; path existence or non-existence
-                       function-expr) ; ST(OptionalBooleanType) or
-                                      ; ST(OptionalNodesType)
+                       function-expr) ; ST(OptionalNodesType)
 filter-path         = rel-path / json-path
 rel-path            = current-node-identifier segments
 current-node-identifier = "@"
@@ -1417,10 +1412,8 @@ a non-empty nodelist. The table also lists the (immediate) subtypes of each type
 | :--                       | :----------------                        | :------                                        |
 | `OptionalNodeOrValueType` | `Node(n)`, `Value(v)`, `Nothing`         | `OptionalNodeType`, `OptionalValueType`        |
 | `OptionalNodeType`        | `Node(n)`, `Nothing`                     |                                                |
-| `OptionalValueType`       | `Value(v)`, `Nothing`                    | `OptionalNodeType`, `ValueType`, `OptionalBooleanType` |
-| `ValueType`               | `Value(v)`                               | `BooleanType`                                  |
-| `OptionalBooleanType`     | `Value(true)`, `Value(false)`, `Nothing` | `BooleanType`                                  |
-| `BooleanType`             | `Value(true)`, `Value(false)`            |                                                |
+| `OptionalValueType`       | `Value(v)`, `Nothing`                    | `OptionalNodeType`, `ValueType`                |
+| `ValueType`               | `Value(v)`                               |                                                |
 | `OptionalNodesType`       | `Nodes(nl)`, `Nothing`                   | `OptionalNodeType`                             |
 {: #tbl-types title="Function extension type system"}
 
@@ -1429,8 +1422,6 @@ Notes:
 * `OptionalNodeOrValueType` is an abstraction of a `comparable` (which may appear on either side of a comparison or as a function argument).
 * `OptionalNodeType` is an abstraction of a Singular Path.
 * `ValueType` is an abstraction of a primitive value.
-* `BooleanType` is an abstraction of a primitive value that is either
-  `true` or `false`.
 * `OptionalValueType` is an abstraction of a primitive value that may
   alternatively be absent (`Nothing`).
 * `OptionalNodesType` is an abstraction of a `filter-path` (which appears
@@ -1461,7 +1452,6 @@ A function expression is correctly typed if all the following are true:
 
 * If it occurs directly in a test expression, the function
 is defined to have a result type in `ST(OptionalNodesType)`.
-or to have a result type in `ST(OptionalBooleanType)`.
 * If it occurs as a `comparable` in a comparison, the function
 is defined to have a result type in `ST(OptionalNodeOrValueType)`.
 * For it and any function expression it contains,
@@ -1534,7 +1524,7 @@ Arguments:
   2. `ValueType` (string conforming to {{-iregexp}})
 
 Result:
-: `OptionalBooleanType` (`true`, `false`, or `Nothing`)
+: `OptionalValueType` (`true`, `false`, or `Nothing`)
 
 The "match" function extension provides a way to check whether (the
 entirety of, see {{search}} below) a given
@@ -1560,7 +1550,7 @@ Arguments:
   2. `ValueType` (string conforming to {{-iregexp}})
 
 Result:
-: `OptionalBooleanType` (`true`, `false`, or `Nothing`)
+: `OptionalValueType` (`true`, `false`, or `Nothing`)
 
 The "search" function extension provides a way to check whether a
 given string contains a substring that matches a given regular
@@ -1589,8 +1579,8 @@ the second argument is not a string conforming to {{-iregexp}}.
 | `$[?count(@.*) == 1]` | Valid typing |
 | `$[?count(1) == 1]` | Invalid typing since `1` is not a path  |
 | `$[?count(foo(@.*)) == 1]` | Valid typing, where `foo` is a function extension with argument of type `OptionalNodesType` and result type `OptionalNodesType` |
-| `$[?match(@.timezone, 'Europe/.*')]`         | Valid typing |
-| `$[?match(@.timezone, 'Europe/.*') == true]` | Invalid typing since `OptionalBooleanType` is not a `comparable` |
+| `$[?match(@.timezone, 'Europe/.*')]`         | Invalid typing since return type is not `OptionalNodesType` |
+| `$[?match(@.timezone, 'Europe/.*') == true]` | Valid typing |
 {: title="Function expression examples"}
 
 ## Segments  {#segments-details}
@@ -2010,8 +2000,8 @@ Column "Change Controller" always has the value "IESG" and the column
 | Function Name | Brief description                  | Input                          | Output            |
 | length        | length of array                    | `OptionalValueType`                | `OptionalValueType`   |
 | count         | size of nodelist                   | `OptionalNodesType`                | `Value`           |
-| match         | regular expression full match      | `OptionalNodeOrValueType`, `Value` | `OptionalBooleanType` |
-| search        | regular expression substring match | `OptionalNodeOrValueType`, `Value` | `OptionalBooleanType` |
+| match         | regular expression full match      | `OptionalNodeOrValueType`, `Value` | `OptionalValueType` |
+| search        | regular expression substring match | `OptionalNodeOrValueType`, `Value` | `OptionalValueType` |
 {: #pre-reg title="Initial Entries in the Function Extensions Subregistry"}
 
 


### PR DESCRIPTION
This is an option for fixing the grammar issues explained in #387 around functions and their role in expressions.

- Removes the `BooleanType` type and makes `match()` and `search()` merely produce `OptionalValueType`.  That value is either JSON `true` or `false`.
- Removes the special handling for functions that can return a JSON `true` or `false` result.

A fallout of this is that `$[?match(@.timezone, 'Europe/.*')]` is not valid/well-formed.