### PR TITLE
`BooleanType` should be logical, not a value, for consistent expression grammar

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1430,6 +1430,7 @@ Notes:
 * `ValueType` is an abstraction of a primitive value.
 * `BooleanType` is an abstraction of the boolean result of a `test-expr`.
   Its "true" and "false" values are not relatable to the JSON literals `true` and `false`.
+  These values have no syntactical representation in JSON Path.
 * `OptionalValueType` is an abstraction of a primitive value that may
   alternatively be absent (`Nothing`).
 * `OptionalNodesType` is an abstraction of a `filter-path` (which appears

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1098,8 +1098,8 @@ A test expression either tests the existence of a node
 designated by an embedded query (see {{extest}}) or tests the
 result of a function expression (see {{fnex}}).
 In the latter case, if the function expression is of type
-`ST(OptionalBooleanType)` (see {{typesys}}), it tests whether the result
-is `true`; if the function expression is of type
+`ST(BooleanType)` (see {{typesys}}), it tests whether the result
+is a logical "true;" if the function expression is of type
 `ST(OptionalNodesType)`, it tests whether the result is different from
 `Nothing`.
 
@@ -1117,7 +1117,7 @@ basic-expr          = paren-expr /
                       test-expr
 test-expr           = [logical-not-op S]
                       (filter-path / ; path existence or non-existence
-                       function-expr) ; ST(OptionalBooleanType) or
+                       function-expr) ; ST(BooleanType) or
                                       ; ST(OptionalNodesType)
 filter-path         = rel-path / json-path
 rel-path            = current-node-identifier segments
@@ -1417,10 +1417,9 @@ a non-empty nodelist. The table also lists the (immediate) subtypes of each type
 | :--                       | :----------------                        | :------                                        |
 | `OptionalNodeOrValueType` | `Node(n)`, `Value(v)`, `Nothing`         | `OptionalNodeType`, `OptionalValueType`        |
 | `OptionalNodeType`        | `Node(n)`, `Nothing`                     |                                                |
-| `OptionalValueType`       | `Value(v)`, `Nothing`                    | `OptionalNodeType`, `ValueType`, `OptionalBooleanType` |
+| `OptionalValueType`       | `Value(v)`, `Nothing`                    | `OptionalNodeType`, `ValueType`                |
 | `ValueType`               | `Value(v)`                               | `BooleanType`                                  |
-| `OptionalBooleanType`     | `Value(true)`, `Value(false)`, `Nothing` | `BooleanType`                                  |
-| `BooleanType`             | `Value(true)`, `Value(false)`            |                                                |
+| `BooleanType`             | `Logic`                                  |                                                |
 | `OptionalNodesType`       | `Nodes(nl)`, `Nothing`                   | `OptionalNodeType`                             |
 {: #tbl-types title="Function extension type system"}
 
@@ -1429,8 +1428,8 @@ Notes:
 * `OptionalNodeOrValueType` is an abstraction of a `comparable` (which may appear on either side of a comparison or as a function argument).
 * `OptionalNodeType` is an abstraction of a Singular Path.
 * `ValueType` is an abstraction of a primitive value.
-* `BooleanType` is an abstraction of a primitive value that is either
-  `true` or `false`.
+* `BooleanType` is an abstraction of the boolean result of a `test-expr`.
+  Its "true" and "false" values are not relatable to the JSON literals `true` and `false`.
 * `OptionalValueType` is an abstraction of a primitive value that may
   alternatively be absent (`Nothing`).
 * `OptionalNodesType` is an abstraction of a `filter-path` (which appears
@@ -1442,6 +1441,7 @@ The abstract instances above can be obtained from the concrete representations i
 | :---------------: | :----------------------:                                           |
 | `Node(n)`         | Singular Path resulting in a nodelist containing just the node `n` |
 | `Value(v)`        | JSON value `v`                                                     |
+| `Logic`           | The result of a `test-expr`: a logical "true" or "false"           |
 | `Nothing`         | Singular Path or `filter-path` resulting in an empty nodelist      |
 | `Nodes(nl)`       | `filter-path` resulting in the non-empty nodelist `nl`             |
 {: #tbl-typerep title="Concrete representations of abstract instances"}
@@ -1461,7 +1461,7 @@ A function expression is correctly typed if all the following are true:
 
 * If it occurs directly in a test expression, the function
 is defined to have a result type in `ST(OptionalNodesType)`.
-or to have a result type in `ST(OptionalBooleanType)`.
+or to have a result type in `ST(BooleanType)`.
 * If it occurs as a `comparable` in a comparison, the function
 is defined to have a result type in `ST(OptionalNodeOrValueType)`.
 * For it and any function expression it contains,
@@ -1534,7 +1534,7 @@ Arguments:
   2. `ValueType` (string conforming to {{-iregexp}})
 
 Result:
-: `OptionalBooleanType` (`true`, `false`, or `Nothing`)
+: `BooleanType` (logical "true" or "false")
 
 The "match" function extension provides a way to check whether (the
 entirety of, see {{search}} below) a given
@@ -1546,11 +1546,8 @@ $[?match(@.date, "1974-05-..")]
 
 Its first argument is an optional string that is matched against the iregexp
 contained in the string that is the second argument.
-The result is `true` if the string matches the iregexp and `false`
+The result is logical "true" if the string matches the iregexp and "false"
 otherwise.
-
-The result is `Nothing` if the first argument is not a string or
-the second argument is not a string conforming to {{-iregexp}}.
 
 
 ### `search` Function Extension {#search}
@@ -1560,7 +1557,7 @@ Arguments:
   2. `ValueType` (string conforming to {{-iregexp}})
 
 Result:
-: `OptionalBooleanType` (`true`, `false`, or `Nothing`)
+: `BooleanType` (logical "true" or "false")
 
 The "search" function extension provides a way to check whether a
 given string contains a substring that matches a given regular
@@ -1575,9 +1572,6 @@ substring that matches the iregexp contained in the string
 that is the second argument.
 The result is `true` if such a substring exists, `false` otherwise.
 
-The result is `Nothing` if the first argument is not a string or
-the second argument is not a string conforming to {{-iregexp}}.
-
 
 ### Examples
 {: unnumbered}
@@ -1590,7 +1584,7 @@ the second argument is not a string conforming to {{-iregexp}}.
 | `$[?count(1) == 1]` | Invalid typing since `1` is not a path  |
 | `$[?count(foo(@.*)) == 1]` | Valid typing, where `foo` is a function extension with argument of type `OptionalNodesType` and result type `OptionalNodesType` |
 | `$[?match(@.timezone, 'Europe/.*')]`         | Valid typing |
-| `$[?match(@.timezone, 'Europe/.*') == true]` | Invalid typing since `OptionalBooleanType` is not a `comparable` |
+| `$[?match(@.timezone, 'Europe/.*') == true]` | Invalid typing since `BooleanType` can only appear in `test-expr` |
 {: title="Function expression examples"}
 
 ## Segments  {#segments-details}
@@ -2010,8 +2004,8 @@ Column "Change Controller" always has the value "IESG" and the column
 | Function Name | Brief description                  | Input                          | Output            |
 | length        | length of array                    | `OptionalValueType`                | `OptionalValueType`   |
 | count         | size of nodelist                   | `OptionalNodesType`                | `Value`           |
-| match         | regular expression full match      | `OptionalNodeOrValueType`, `Value` | `OptionalBooleanType` |
-| search        | regular expression substring match | `OptionalNodeOrValueType`, `Value` | `OptionalBooleanType` |
+| match         | regular expression full match      | `OptionalNodeOrValueType`, `Value` | `BooleanType` |
+| search        | regular expression substring match | `OptionalNodeOrValueType`, `Value` | `BooleanType` |
 {: #pre-reg title="Initial Entries in the Function Extensions Subregistry"}
 
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1429,8 +1429,8 @@ Notes:
 * `OptionalNodeType` is an abstraction of a Singular Path.
 * `ValueType` is an abstraction of a primitive value.
 * `BooleanType` is an abstraction of the boolean result of a `test-expr`.
-  Its "true" and "false" values are not relatable to the JSON literals `true` and `false`.
-  These values have no syntactical representation in JSON Path.
+  Its "true" and "false" values are not relatable to the JSON literals `true` and `false`
+  and have no syntactical representation in JSON Path.
 * `OptionalValueType` is an abstraction of a primitive value that may
   alternatively be absent (`Nothing`).
 * `OptionalNodesType` is an abstraction of a `filter-path` (which appears


### PR DESCRIPTION
This is another option to resolve #387 (see #395 for the first option).

For this, `BooleanType` is not a value but represents the logical result of `test-expr`.

- Provides for functions that can return a true or false result by declaring that such a result is logical, not JSON.
- Removes `OptionalBooleanType` is no longer necessary, as `Nothing` in a `test-expr` behaves the same as logical _false_.

A fallout of this is that `$[?match(@.timezone, 'Europe/.*')==false]` is not valid/well-formed.