### PR TITLE
Filter selector cleanup

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1093,7 +1093,7 @@ of each array element or object member value of the structured value being
 filtered; this element or member value is then known as the *current node*.
 
 The current node can be used as the start of one or more JSONPath
-queries used inside subexpressions of the filter expression, notated
+queries in subexpressions of the filter expression, notated
 via the current-node-identifier `@`.
 Each JSONPath query can be used either for testing existence of a
 result of the query, for obtaining a specific JSON value resulting

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1464,7 +1464,7 @@ a type system is first introduced.
 Each parameter and the result of a function extension must have a declared type.
 
 A type is a set of instances.
-Declared types enable testing a JSONPath query for well-typedness
+Declared types enable checking a JSONPath query for well-typedness
 independent of any argument the JSONPath query is applied to.
 
 {{tbl-types}} defines the available types in terms of abstract instances, where `n` denotes a node, `v` denotes a value, and `nl` denotes

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -406,7 +406,7 @@ elements from an array, giving a start position, an end position, and
 an optional step value that moves the position from the start to the
 end.
 
-Filter expressions `?<expr>` select certain children of an object or array, as in:
+Filter expressions `?<logical-expr>` select certain children of an object or array, as in:
 
 ~~~~ JSONPath
 $.store.book[?@.price < 10].title
@@ -430,7 +430,7 @@ $.store.book[?@.price < 10].title
 | `*`                 | [wildcard selector](#name-selector): selects all children of a node                                                    |
 | `3`                 | [index selector](#index-selector): selects an indexed child of an array (from 0)                                        |
 | `0:100:5`           | [array slice selector](#slice): start:end:step for arrays                                                               |
-| `?<expr>`           | [filter selector](#filter-selector): selects particular children using a logical expression                      |
+| `?<logical-expr>`   | [filter selector](#filter-selector): selects particular children using a logical expression                      |
 | `length(@.foo)`     | [function extension](#fnex): invokes a function in a filter expression                                                  |
 {: #tbl-overview title="Overview of JSONPath syntax"}
 
@@ -1117,7 +1117,7 @@ function expressions are not in use.
 #### Syntax
 {: unnumbered}
 
-The filter selector has the form `?<expr>`.
+The filter selector has the form `?<logical-expr>`.
 
 ~~~~ abnf
 filter-selector     = "?" S logical-expr
@@ -2246,7 +2246,7 @@ The descendant operators, starting with `..`, borrowed from {{E4X}}, are similar
 The array slicing construct `[start:end:step]` is unique to JSONPath,
 inspired by {{SLICE}} from ECMASCRIPT 4.
 
-Filter expressions are supported via the syntax `?<expr>` as in
+Filter expressions are supported via the syntax `?<logical-expr>` as in
 
 ~~~~ JSONPath
 $.store.book[?@.price < 10].title

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1664,7 +1664,8 @@ If the first argument is not a string or the second argument is not a
 string conforming to {{-iregexp}}, the result is `LogicalFalse`. <!-- XXX -->
 Otherwise, the string that is the first argument is searched for at
 least one substring that matches the iregexp contained in the string
-that is the second argument; the result is `LogicalTrue` if
+that is the second argument; the result is `LogicalTrue` if such a
+substring exists and `LogicalFalse` otherwise.
 
 
 ### Examples

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1480,7 +1480,7 @@ a nodelist.
 Notes:
 
 * `ValueType` is an abstraction of a JSON value or `Nothing`.
-* `LogicalType` is an abstraction of a the result of a `test-expr`.
+* `LogicalType` is an abstraction of the value of a `logical-expr`.
   Its `LogicalTrue` and `LogicalFalse` values are not relatable to
   the JSON literals `true` and `false` and have no syntactical representation in JSON Path.
 * `NodesType` is an abstraction of a `filter-path` (which appears

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1085,7 +1085,7 @@ For each iteration (element/member), a logical expression, the *filter expressio
 is evaluated which decides whether the node of
 the element/member is selected.
 (While a logical expression evaluates to what mathematically is a
-Boolean value, we use the term *logical* to maintain a distinction from
+Boolean value, this specification uses the term *logical* to maintain a distinction from
 the Boolean values that JSON can represent.)
 
 During the iteration process, the filter expression receives the node
@@ -1535,7 +1535,7 @@ A function expression is well-typed if all of the following are true:
    * The argument is a Singular Path or `filter-path` (which includes
      Singular Paths), or a function expression with declared result
      type `NodesType`.  Where the declared type of the parameter is
-     not `NodeType`, a conversion applies.
+     not `NodesType`, a conversion applies.
 
 #### Conversion example
 {:unnumbered}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -517,7 +517,7 @@ to the JSONPath processing (e.g., index values and steps) MUST be
 within the range of exact values defined in I-JSON {{-i-json}}, namely
 within the interval \[-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1].
 
-2. Uses of function extensions must be correctly typed,
+2. Uses of function extensions must be *well-typed*,
 as described in {{fnex}}.
 
 A JSONPath implementation MUST raise an error for any query which is not
@@ -1112,6 +1112,8 @@ function is declared.
 The type system is limited in scope; its function is to express
 restrictions that, without functions, are implicit in the grammar of
 filter expressions.
+The type system also guides conversions ({{type-conv}}) that are
+implicit in the grammar without the use of function expressions.
 
 #### Syntax
 {: unnumbered}
@@ -1457,10 +1459,10 @@ According to {{filter-selector}}, a `function-expr` is valid as a `filter-path`
 or a `comparable`.
 
 Any function expressions in a query must be well-formed (by conforming to the above ABNF)
-and correctly typed,
+and well-typed,
 otherwise the JSONPath implementation MUST raise an error
 (see {{synsem-overview}}).
-To define which function expressions are correctly typed,
+To define which function expressions are well-typed,
 a type system is first introduced.
 
 ### Type System for Function Expressions {#typesys}
@@ -1516,9 +1518,9 @@ The following type conversions may occur:
     is `LogicalTrue`.
   * If the nodelist is empty, the conversion result is `LogicalFalse`.
 
-The type correctness of function expressions can now be defined in terms of this type system.
+The well-typedness of function expressions can now be defined in terms of this type system.
 
-### Type Correctness of Function Expressions
+### Well-Typedness of Function Expressions
 
 A function expression is well-typed if all of the following are true:
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -2082,7 +2082,7 @@ Brief description:
 : a brief description
 
 Parameters:
-: A comma-separated list of zero or more declared types, each for one of the
+: A comma-separated list of zero or more declared types, one for each of the
   arguments expected for this function extension
 
 Result:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1468,7 +1468,7 @@ Declared types enable checking a JSONPath query for well-typedness
 independent of any argument the JSONPath query is applied to.
 
 {{tbl-types}} defines the available types in terms of abstract instances, where `n` denotes a node, `v` denotes a value, and `nl` denotes
-a non-empty nodelist.
+a nodelist.
 
 | Type                 | Abstract Instances                       |
 | :--                  | :----------------                        |

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1107,7 +1107,7 @@ functions predefined, see {{fnex}}, and the ability to register further
 functions provided by the Function Extensions sub-registry ({{iana-fnex}}).
 When a function is defined, it is given a unique name, and its return value and each of its arguments is given a
 *declared type*.
-The type system is limited in scope; its function is to express
+The type system is limited in scope; its purpose is to express
 restrictions that, without functions, are implicit in the grammar of
 filter expressions.
 The type system also guides conversions ({{type-conv}}) that are

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1679,7 +1679,7 @@ substring exists and `LogicalFalse` otherwise.
 | `$[?count(1) == 1]` | not well-typed since `1` is not a path  |
 | `$[?count(foo(@.*)) == 1]` | well-typed, where `foo` is a function extension with a parameter of type `NodesType` and result type `NodesType` |
 | `$[?match(@.timezone, 'Europe/.*')]`         | well-typed |
-| `$[?match(@.timezone, 'Europe/.*') == true]` | not well-typed as JSONPath logicals and JSON booleans do not mix |
+| `$[?match(@.timezone, 'Europe/.*') == true]` | not well-typed as JSONPath logicals may not be used in comparisons |
 {: title="Function expression examples"}
 
 ## Segments  {#segments-details}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1104,7 +1104,7 @@ Within the logical expression for a filter selector, function
 expressions can be used to operate on nodelists and values.
 The set of available functions is extensible, with a number of
 functions predefined, see {{fnex}}, and the ability to register further
-functions in the Function Extensions sub-registry ({{iana-fnex}}).
+functions provided by the Function Extensions sub-registry ({{iana-fnex}}).
 When a function is defined, it is given a unique name, and the
 *declared type*
 of each of its arguments as well as the declared type returned from the

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1105,10 +1105,8 @@ expressions can be used to operate on nodelists and values.
 The set of available functions is extensible, with a number of
 functions predefined, see {{fnex}}, and the ability to register further
 functions provided by the Function Extensions sub-registry ({{iana-fnex}}).
-When a function is defined, it is given a unique name, and the
-*declared type*
-of each of its arguments as well as the declared type returned from the
-function is declared.
+When a function is defined, it is given a unique name, and its return value and each of its arguments is given a
+*declared type*.
 The type system is limited in scope; its function is to express
 restrictions that, without functions, are implicit in the grammar of
 filter expressions.

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1110,8 +1110,9 @@ When a function is defined, it is given a unique name, and its return value and 
 The type system is limited in scope; its purpose is to express
 restrictions that, without functions, are implicit in the grammar of
 filter expressions.
-The type system also guides conversions ({{type-conv}}) that are
-implicit in the grammar without the use of function expressions.
+The type system also guides conversions ({{type-conv}}) that mimic the
+way different kinds of expressions are handled in the grammar when
+function expressions are not in use.
 
 #### Syntax
 {: unnumbered}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1481,7 +1481,7 @@ Notes:
 
 * `ValueType` is an abstraction of a JSON value or `Nothing`.
 * `LogicalType` is an abstraction of the value of a `logical-expr`.
-  Its `LogicalTrue` and `LogicalFalse` values are not relatable to
+  Its `LogicalTrue` and `LogicalFalse` values are not related to
   the JSON literals `true` and `false` and have no syntactical representation in JSON Path.
 * `NodesType` is an abstraction of a `filter-path` (which appears
   in a test expression or as a function argument).

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1160,7 +1160,7 @@ paren-expr          = [logical-not-op S] "(" S logical-expr S ")"
 logical-not-op      = "!"               ; logical NOT operator
 ~~~~
 
-A test expression is shorthand for a comparison that
+A test expression
 either tests the existence of a node
 designated by an embedded query (see {{extest}}) or tests the
 result of a function expression (see {{fnex}}).

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1079,7 +1079,7 @@ The following examples show the array slice selector in use by a child segment.
 Filter selectors are used to iterate over the elements or members of
 structured values, i.e., JSON arrays and objects.
 The structured values are identified in the nodelist offered by the
-child or descendant segment the filter selector is used in.
+child or descendant segment using the filter selector.
 
 For each iteration (element/member), a logical expression is
 evaluated, the *filter expression*, which decides whether the node of

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -185,7 +185,7 @@ Additional terms used in this document are defined below.
 
 Value:
 : As per {{-json}}, a structure conforming to the generic data model of JSON, i.e.,
-  composed of components such as structured values, namely JSON objects and arrays, and
+  composed of constituents such as structured values, namely JSON objects and arrays, and
   primitive data, namely numbers and text strings as well as the special
   values null, true, and false.
   {{-json}} focuses on the textual representation of JSON values and
@@ -1123,7 +1123,7 @@ The filter selector has the form `?<expr>`.
 filter-selector     = "?" S logical-expr
 ~~~~
 
-As the filter expression is composed of side-effect free components,
+As the filter expression is composed of side-effect free constituents,
 the order of evaluation does not need to be (and is not) defined.
 Similarly, for conjunction (`&&`) and disjunction (`||`) (defined later),
 both a short-circuiting and a fully evaluating
@@ -2320,7 +2320,7 @@ is known only in a general way.
 
 A Normalized JSONPath can be converted into a JSON Pointer by converting the syntax,
 without knowledge of any JSON value. The inverse is not generally true: a numeric
-path component in a JSON Pointer may identify a member value of an object or an element of an array.
+reference token (path component) in a JSON Pointer may identify a member value of an object or an element of an array.
 For conversion to a JSONPath query, knowledge of the structure of the JSON value is
 needed to distinguish these cases.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1480,12 +1480,12 @@ a nodelist.
 Notes:
 
 * `ValueType` is an abstraction of a JSON value or `Nothing`.
-* `LogicalType` is an abstraction of the value of a `logical-expr`.
-  Its `LogicalTrue` and `LogicalFalse` values are not related to
-  the JSON literals `true` and `false` and have no syntactical representation in JSON Path.
+* `LogicalType` is an abstraction of the result of a `logical-expr`.
+  Its two instances, `LogicalTrue` and `LogicalFalse`, are not related to
+  the JSON literals `true` and `false` and have no syntactical representation in JSONPath.
 * `NodesType` is an abstraction of a `filter-path` (which appears
   in a test expression or as a function argument).
-  Members of `NodesType` have no syntactical representation in JSON Path.
+  Members of `NodesType` have no syntactical representation in JSONPath.
 
 The abstract instances above can be obtained from the concrete representations in {{tbl-typerep}}.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1081,8 +1081,8 @@ structured values, i.e., JSON arrays and objects.
 The structured values are identified in the nodelist offered by the
 child or descendant segment using the filter selector.
 
-For each iteration (element/member), a logical expression is
-evaluated, the *filter expression*, which decides whether the node of
+For each iteration (element/member), a logical expression, the *filter expression*,
+is evaluated which decides whether the node of
 the element/member is selected.
 (While a logical expression evaluates to what mathematically is a
 Boolean value, we use the term *logical* to maintain a distinction from

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -211,6 +211,7 @@ Query:
 
 Argument:
 : Short name for the value a JSONPath expression is applied to.
+  (Also used for actual parameters of function-expressions.)
 
 Location:
 : the position of a value within the argument. This can be thought of
@@ -254,6 +255,9 @@ Nodelist:
 : A list of nodes.
   While a nodelist can be represented in JSON, e.g. as an array, this document
   does not require or assume any particular representation.
+
+Parameter:
+: Formal parameter that can take Arguments (actual parameters) in a function-expression.
 
 Normalized Path:
 : A simple form of JSONPath expression that identifies a node in a value by
@@ -1074,38 +1078,40 @@ The following examples show the array slice selector in use by a child segment.
 
 Filter selectors are used to iterate over the elements or members of
 structured values, i.e., JSON arrays and objects.
-The structured values are identified in the nodelist offered by a
-child or descendant segment.
+The structured values are identified in the nodelist offered by the
+child or descendant segment the filter selector is used in.
 
 For each iteration (element/member), a logical expression is
 evaluated, the *filter expression*, which decides whether the node of
 the element/member is selected.
-(While a logical expression evaluates to a Boolean value, we use the
-term logical to maintain a distinction from the Boolean values that
-JSON can represent.)
+(While a logical expression evaluates to what mathematically is a
+Boolean value, we use the term *logical* to maintain a distinction from
+the Boolean values that JSON can represent.)
 
 During the iteration process, the filter expression receives the node
-of each array element or object member of the structured value being
-filtered, which is then known as the *current node*.
+of each array element or value in an object member of the structured value being
+filtered; this element or member value is then known as the *current node*.
 
 The current node can be used as the start of one or more JSONPath
 queries used inside subexpressions of the filter expression, notated
 via the current-node-identifier `@`.
 Each JSONPath query can be used either for testing existence of a
-result of the query, or for obtaining a specific JSON value resulting
-from that query that can then be used in a comparison.
+result of the query, for obtaining a specific JSON value resulting
+from that query that can then be used in a comparison, or as a
+*function argument*.
 
 Within the logical expression for a filter selector, function
 expressions can be used to operate on nodelists and values.
 The set of available functions is extensible, with a number of
 functions predefined, see {{fnex}}, and the ability to register further
 functions in the Function Extensions sub-registry ({{iana-fnex}}).
-When a function is defined, it is given a unique name, and the *type*
-of each of its arguments as well as the type returned from the
+When a function is defined, it is given a unique name, and the
+*declared type*
+of each of its arguments as well as the declared type returned from the
 function is declared.
 The type system is limited in scope; its function is to express
-restrictions that are otherwise implicit in the grammar of filter
-expressions.
+restrictions that, without functions, are implicit in the grammar of
+filter expressions.
 
 #### Syntax
 {: unnumbered}
@@ -1116,9 +1122,10 @@ The filter selector has the form `?<expr>`.
 filter-selector     = "?" S logical-expr
 ~~~~
 
-As the expression is composed of side-effect free components,
+As the filter expression is composed of side-effect free components,
 the order of evaluation does not need to be (and is not) defined.
-Similarly, for conjunction (`&&`) and disjunction (`||`) (defined later), both a short-circuiting and a fully evaluating
+Similarly, for conjunction (`&&`) and disjunction (`||`) (defined later),
+both a short-circuiting and a fully evaluating
 implementation will lead to the same result; both implementation
 strategies are therefore valid.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1147,7 +1147,7 @@ paren-expr          = [logical-not-op S] "(" S logical-expr S ")"
 logical-not-op      = "!"               ; logical NOT operator
 ~~~~
 
-A test expression is shorthand for a comparison
+A test expression is shorthand for a comparison that
 either tests the existence of a node
 designated by an embedded query (see {{extest}}) or tests the
 result of a function expression (see {{fnex}}).
@@ -1175,10 +1175,10 @@ current-node-identifier = "@"
 ~~~~
 
 
-Comparison expression are available for comparisons between primitive
+Comparison expressions are available for comparisons between primitive
 values (that is, numbers, strings, `true`, `false`, and `null`).
 These can be obtained via literal values; Singular Paths, each of
-which selects at most one node the value of which is then used, and
+which selects at most one node the value of which is then used; and
 function expressions (see {{fnex}}) that return a primitive value or at
 most one node.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1633,7 +1633,7 @@ string matches a given regular expression, which is in {{-iregexp}} form.
 $[?match(@.date, "1974-05-..")]
 ~~~
 
-Its arguments are instances of ValueType.
+Its arguments are instances of `ValueType`.
 If the first argument is not a string or the second argument is not a
 string conforming to {{-iregexp}}, the result is `LogicalFalse`. <!-- XXX -->
 Otherwise, the string that is the first argument is matched against
@@ -1659,7 +1659,7 @@ expression, which is in {{-iregexp}} form.
 $[?search(@.author, "[BR]ob")]
 ~~~
 
-Its arguments are instances of ValueType.
+Its arguments are instances of `ValueType`.
 If the first argument is not a string or the second argument is not a
 string conforming to {{-iregexp}}, the result is `LogicalFalse`. <!-- XXX -->
 Otherwise, the string that is the first argument is searched for at

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1089,7 +1089,7 @@ Boolean value, this specification uses the term *logical* to maintain a distinct
 the Boolean values that JSON can represent.)
 
 During the iteration process, the filter expression receives the node
-of each array element or value in an object member of the structured value being
+of each array element or object member value of the structured value being
 filtered; this element or member value is then known as the *current node*.
 
 The current node can be used as the start of one or more JSONPath

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1105,7 +1105,7 @@ expressions can be used to operate on nodelists and values.
 The set of available functions is extensible, with a number of
 functions predefined, see {{fnex}}, and the ability to register further
 functions provided by the Function Extensions sub-registry ({{iana-fnex}}).
-When a function is defined, it is given a unique name, and its return value and each of its arguments is given a
+When a function is defined, it is given a unique name, and its return value and each of its parameters is given a
 *declared type*.
 The type system is limited in scope; its purpose is to express
 restrictions that, without functions, are implicit in the grammar of
@@ -1460,7 +1460,7 @@ a type system is first introduced.
 
 ### Type System for Function Expressions {#typesys}
 
-Each argument and result of a function extension must have a declared type.
+Each parameter and the result of a function extension must have a declared type.
 
 A type is a set of instances.
 Declared types enable testing a JSONPath query for well-typedness
@@ -1566,7 +1566,7 @@ value and thus feeds a comparison with `Nothing`.
 
 ### `length` Function Extension {#length}
 
-Arguments:
+Parameters:
 : 1. `ValueType`
 
 Result:
@@ -1595,7 +1595,7 @@ instance of `ValueType`: an unsigned integer or `Nothing`.
 
 ### `count` Function Extension {#count}
 
-Arguments:
+Parameters:
 : 1. `NodesType`
 
 Result:
@@ -1617,7 +1617,7 @@ Note that there is no deduplication of the nodelist.
 
 ### `match` Function Extension {#match}
 
-Arguments:
+Parameters:
 : 1. `ValueType` (string)
   2. `ValueType` (string conforming to {{-iregexp}})
 
@@ -1643,7 +1643,7 @@ the result is `LogicalTrue` if the string matches the iregexp and
 
 ### `search` Function Extension {#search}
 
-Arguments:
+Parameters:
 : 1. `ValueType` (string)
   2. `ValueType` (string conforming to {{-iregexp}})
 
@@ -1675,7 +1675,7 @@ that is the second argument; the result is `LogicalTrue` if
 | `$[?length(@.*) < 3]` | not well-typed since `@.*` is a non-singular path |
 | `$[?count(@.*) == 1]` | well-typed |
 | `$[?count(1) == 1]` | not well-typed since `1` is not a path  |
-| `$[?count(foo(@.*)) == 1]` | well-typed, where `foo` is a function extension with argument of type `NodesType` and result type `NodesType` |
+| `$[?count(foo(@.*)) == 1]` | well-typed, where `foo` is a function extension with a parameter of type `NodesType` and result type `NodesType` |
 | `$[?match(@.timezone, 'Europe/.*')]`         | well-typed |
 | `$[?match(@.timezone, 'Europe/.*') == true]` | not well-typed as JSONPath logicals and JSON booleans do not mix |
 {: title="Function expression examples"}


### PR DESCRIPTION
General simplification and cleanup of the type system used in filter selectors.

Intended to supersede #402, which this is based on.
Intended to supersede #395.
Closes #387.
Closes #389.
Closes #401.

