### PR TITLE
Sharpen up the absence of syntactical representations

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1484,10 +1484,10 @@ Notes:
 * `ValueType` is an abstraction of a JSON value or `Nothing`.
 * `LogicalType` is an abstraction of the result of a `logical-expr`.
   Its two instances, `LogicalTrue` and `LogicalFalse`, are not related to
-  the JSON literals `true` and `false` and have no syntactical representation in JSONPath.
+  the JSON literals `true` and `false` and have no direct syntactical representation in JSONPath.
 * `NodesType` is an abstraction of a `filter-path` (which appears
   in a test expression or as a function argument).
-  Members of `NodesType` have no syntactical representation in JSONPath.
+  Members of `NodesType` have no direct syntactical representation in JSONPath.
 
 The abstract instances above can be obtained from the concrete representations in {{tbl-typerep}}.
 


### PR DESCRIPTION
There are some syntactical representations, e.g.:

* LogicalTrue can be represented by (1==1).
* LogicalFalse can be represented by (1==0).
* Nothing can be represented by a query that always returns the empty nodelist, such as $[?1==0].

But these are somewhat circuitous rather than direct.

See https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/pull/403#discussion_r1122546568