### PR TITLE
Improve well typedness rules

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1521,19 +1521,21 @@ A function expression is well-typed if all of the following are true:
   to have a result type of `LogicalType`, `SingleNodeType`, or `NodesType`.
 * If it occurs directly as a `comparable` in a comparison, the
   function is declared to have a result type of `ValueType` or `SingleNodeType`.
-* Otherwise, it occurs as an argument to a further function
-  expression and the following rules for function arguments apply to
-  its declared result type.
 * Each argument of the function conforms to the declared type of the corresponding declared
-  parameter according to one of the following rules:
-   * The argument is a function expression with declared result type that is the same as
-     the declared type of the parameter.
-   * The argument is a function expression with declared result type `SingleNodeType` and
-     the declared type of the parameter is `NodesType`.
-   * The argument is a literal primitive value and the declared type of the parameter is `ValueType`.
-   * The argument is a Singular Path and the declared type of the parameter is `SingleNodeType`.
-   * The argument is a Singular Path or `filter-path` (which includes
-     Singular Paths) and the declared type of the parameter is `NodesType`.
+  parameter according to one of the following scenarios:
+   * The declared type of the parameter is `ValueType` and the argument is one of:
+     * a function with declared type of `ValueType` or `SingleNodeType`
+     * a `singular-path`
+     * a `literal`
+   * The declared type of the parameter is `LogicalType` and the argument is one of:
+     * a function with declared type of `LogicalType`, `SingleNodeType`, or `NodesType`
+     * a `filter-path` (which includes `singular-path`)
+   * The declared type of the parameter is `SingleNodeType` and the argument is one of:
+     * a function with declared type of `SingleNodeType`
+     * a `singular-path`
+   * The declared type of the parameter is `NodesType` and the argument is one of:
+     * a function with declared type of `SingleNodeType` or `NodesType`
+     * a `filter-path`
 
 ### `length` Function Extension {#length}
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1499,9 +1499,8 @@ Notes:
   Members of `SingleNodeType` have no direct syntactical representation in JSONPath.
 * `NodesType` is an abstraction of a `filter-path` (which appears
   in a test expression or as a function argument).
-  Members of `NodesType` have no direct syntactical representation in JSONPath.
-* `SingleNodeType` is a subtype of `NodesType`. An instance of `SingleNodeType` is well-typed
-  wherever an instance of `NodesType` is well-typed.
+  Members of `NodesType` have no syntactical representation in JSONPath.
+* An instance of `SingleNodeType` is well-typed wherever an instance of `NodesType` is well-typed.
 
 The abstract instances above can be obtained from the concrete representations in {{tbl-typerep}}.
 
@@ -1527,8 +1526,10 @@ A function expression is well-typed if all of the following are true:
   its declared result type.
 * Each argument of the function conforms to the declared type of the corresponding declared
   parameter according to one of the following rules:
-   * The argument is a function expression with declared result type that is the same as,
-     or a subtype of, the declared type of the parameter.
+   * The argument is a function expression with declared result type that is the same as
+     the declared type of the parameter.
+   * The argument is a function expression with declared result type `SingleNodeType` and
+     the declared type of the parameter is `NodesType`.
    * The argument is a literal primitive value and the declared type of the parameter is `ValueType`.
    * The argument is a Singular Path and the declared type of the parameter is `SingleNodeType`.
    * The argument is a Singular Path or `filter-path` (which includes

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1276,7 +1276,7 @@ The comparison operators `==` and `<` are defined first and then these are used 
 When a path or function expression resulting in an empty nodelist appears on either side of a comparison:
 
 * a comparison using the operator `==` yields true if and only if the comparison
-is between two expressions, each of which is a path or a function expression, and each of which result in an empty nodelist.
+is between two `comparable`s, each of which is a path or a function expression, and each of which result in an empty nodelist.
 
 * a comparison using the operator `<` yields false.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1521,8 +1521,8 @@ A function expression is well-typed if all of the following are true:
   to have a result type of `LogicalType`, `SingleNodeType`, or `NodesType`.
 * If it occurs directly as a `comparable` in a comparison, the
   function is declared to have a result type of `ValueType` or `SingleNodeType`.
-* If it occurs as an argument to a further function
-  expression, the following rules for function arguments apply to
+* Otherwise, it occurs as an argument to a further function
+  expression and the following rules for function arguments apply to
   its declared result type.
 * Each argument of the function conforms to the declared type of the corresponding declared
   parameter according to one of the following rules:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1522,7 +1522,7 @@ A function expression is well-typed if all of the following are true:
 * If it occurs directly as a `comparable` in a comparison, the
   function is declared to have a result type of `ValueType` or `SingleNodeType`.
 * Each argument of the function conforms to the declared type of the corresponding declared
-  parameter according to one of the following scenarios:
+  parameter according to one of the following:
    * The declared type of the parameter is `ValueType` and the argument is one of:
      * a function with declared type of `ValueType` or `SingleNodeType`
      * a `singular-path`

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -733,15 +733,17 @@ HEXDIG              = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 
 Note: `double-quoted` strings follow the JSON string syntax ({{Section 7 of RFC8259}});
 `single-quoted` strings follow an analogous pattern ({{syntax-index}}).
-No attempt was made to improve on this syntax, so characters with
-scalar values above 0x10000, such as <u format="num-lit-name">🤔</u>, need to be represented
+No attempt was made to improve on this syntax, so if it is desired to
+escape characters with
+scalar values above 0x10000, such as <u format="num-lit-name">🤔</u>,
+they need to be represented
 by a pair of surrogate escapes (`"\uD83E\uDD14"` in this case).
 
 #### Semantics
 {: unnumbered}
 
 A `name-selector` string MUST be converted to a
-member name M by removing the surrounding quotes and
+member name `M` by removing the surrounding quotes and
 replacing each escape sequence with its equivalent Unicode character, as
 in the table below:
 
@@ -760,15 +762,15 @@ in the table below:
 {: title="Escape Sequence Replacements" cols="c c"}
 
 Applying the `name-selector` to an object node
-selects a member value whose name equals the member name M,
+selects a member value whose name equals the member name `M`,
 or selects nothing if there is no such member value.
 Nothing is selected from a value that is not an object.
 
-Note that processing the name selector requires comparing the member name string M
+Note that processing the name selector requires comparing the member name string `M`
 with member name strings in the JSON to which the selector is being applied.
 Two strings MUST be considered equal if and only if they are identical
 sequences of Unicode scalar values. In other words, normalization operations
-MUST NOT be applied to either the member name string M from the JSONPath or to
+MUST NOT be applied to either the member name string `M` from the JSONPath or to
 the member name strings in the JSON prior to comparison.
 
 #### Examples
@@ -1111,8 +1113,10 @@ When a function is defined, it is given a unique name, and its return value and 
 The type system is limited in scope; its purpose is to express
 restrictions that, without functions, are implicit in the grammar of
 filter expressions.
-The type system also guides conversions ({{type-conv}}) that mimic the
-way different kinds of expressions are handled in the grammar when
+The type system is supported by the two conversion functions `exist`
+and `value` (see Sections {{<exist-fn}} and {{<value-fn}}), which enable
+explicitly performing transitions between different types, mimicking
+the way different kinds of expressions are handled in the grammar when
 function expressions are not in use.
 
 #### Syntax
@@ -1164,20 +1168,18 @@ logical-not-op      = "!"               ; logical NOT operator
 A test expression
 either tests the existence of a node
 designated by an embedded query (see {{extest}}) or tests the
-result of a function expression (see {{fnex}}).
-In the latter case, if the function result type is declared as
-`LogicalType` (see {{typesys}}), it tests whether the result
-is `LogicalTrue`; if the function result type is declared as
-`NodesType`, it tests whether the result is non-empty.
-If the declared function result type is `ValueType`, its use in a
-test expression is not well-typed.
+result of a function expression of declared type `LogicalType` (see
+{{fnex}}).
+In the latter case, the test expression tests whether the function
+result is `LogicalTrue`.
+If the declared function result type is any other than `LogicalType`,
+its use in a test expression is not well-typed.
 
 ~~~ abnf
 
 test-expr           = [logical-not-op S]
                       (filter-path /  ; path existence/non-existence
-                       function-expr) ; LogicalType or
-                                      ; NodesType
+                       function-expr) ; LogicalType
 filter-path         = rel-path / json-path
 rel-path            = current-node-identifier segments
 current-node-identifier = "@"
@@ -1188,15 +1190,16 @@ Comparison expressions are available for comparisons between primitive
 values (that is, numbers, strings, `true`, `false`, and `null`).
 These can be obtained via literal values; Singular Paths, each of
 which selects at most one node the value of which is then used; and
-function expressions (see {{fnex}}) of type `ValueType` or
-`NodesType` (see {{type-conv}}).
+function expressions (see {{fnex}}) of type `ValueType`.
+If the declared function result type is any other than `ValueType`,
+its use in a comparison expression is not well-typed.
 
 ~~~~ abnf
 comparison-expr     = comparable S comparison-op S comparable
 literal             = number / string-literal /
                       true / false / null
 comparable          = literal /
-                      singular-path /   ; Singular Path value
+                      singular-path /   ; Singular Path -> value
                       function-expr  ; ValueType
 comparison-op       = "==" / "!=" /
                       "<=" / ">=" /
@@ -1449,10 +1452,13 @@ function-argument   = literal /
                       function-expr
 ~~~
 
-A function argument is a `filter-path` or a `comparable`.
+A function argument is a `filter-path` (which yields a `NodesType`), a
+literal (which yields a `ValueType`), or a function expression (which
+yields the declared type of the function named).
 
-According to {{filter-selector}}, a `function-expr` is valid as a `filter-path`
-or a `comparable`.
+According to {{filter-selector}}, a `function-expr` is valid as part of
+a test expression (if the declared type is `NodesType`) or as a
+`comparable` (if the declared type is `ValueType`).
 
 Any function expressions in a query must be well-formed (by conforming to the above ABNF)
 and well-typed,
@@ -1463,7 +1469,7 @@ a type system is first introduced.
 
 ### Type System for Function Expressions {#typesys}
 
-Each parameter and the result of a function extension must have a declared type.
+Each parameter as well as the result of a function extension must have a declared type.
 
 A type is a set of instances.
 Declared types enable checking a JSONPath query for well-typedness
@@ -1498,22 +1504,6 @@ The abstract instances above can be obtained from the concrete representations i
 | `Nodes(nl)`       | A list of zero or more nodes, e.g., from a `filter-path` resulting in the nodelist `nl`, which may or may not be empty  |
 {: #tbl-typerep title="Concrete representations of abstract instances"}
 
-### Type Conversions {#type-conv}
-
-The following type conversions may occur:
-
-* Where an expression with a declared type of `NodesType` needs to be
-  converted to a `ValueType`, the conversion proceeds as follows:
-  * If the nodelist contains a single node, the conversion result is
-    the value of the node.
-  * If the nodelist is empty or contains multiple nodes, the
-    conversion result is `Nothing`.
-* Where a member of `NodesType` needs to be converted to a
-  `LogicalType`, the conversion proceeds as follows:
-  * If the nodelist contains one or more nodes, the conversion result
-    is `LogicalTrue`.
-  * If the nodelist is empty, the conversion result is `LogicalFalse`.
-
 The well-typedness of function expressions can now be defined in terms of this type system.
 
 ### Well-Typedness of Function Expressions
@@ -1521,11 +1511,9 @@ The well-typedness of function expressions can now be defined in terms of this t
 A function expression is well-typed if all of the following are true:
 
 * If it occurs directly in a test expression, the function is declared
-  to have a result type of `LogicalType`, or (conversion applies)
-  `NodesType`.
+  to have a result type of `LogicalType`.
 * If it occurs directly as a `comparable` in a comparison, the
-  function is declared to have a result type of `ValueType`, or
-  (conversion applies) `NodesType`.
+  function is declared to have a result type of `ValueType`.
 * Otherwise, it is occurring as an argument to a further function
   expression, and the following rules for function arguments apply to
   its declared result type.
@@ -1535,36 +1523,80 @@ A function expression is well-typed if all of the following are true:
    * The argument is a literal primitive value and the defined type of the parameter is `ValueType`.
    * The argument is a Singular Path or `filter-path` (which includes
      Singular Paths), or a function expression with declared result
-     type `NodesType`.  Where the declared type of the parameter is
-     not `NodesType`, a conversion applies.
+     type `NodesType`.
 
-#### Conversion example
-{:unnumbered}
+{{tab-exist-value}} summarizes how the two conversion functions can be
+used to make use of functions returning nodelists, using a
+hypothetical function `fn` of declared type `NodesType`: The table
+gives the result of the conversion function, and the effect of that
+result on the expression given. (`fn` is a hypothetical function
+extension that takes and results in `NodesType`; this function will
+also be used in example further below.)
 
-While functions returning `NodesType` can appear in both comparisons and test expressions,
-path authors must be aware of the conversions and the potential outcomes.
-Specifically, nodelists convert to values and logicals according to {{tbl-typeconv}}:
 
-| Function return        | Converted as Value    | Converted as Logical |
-| :-:                    | :-:                   | :-:                  |
-| empty nodelist         | `Nothing`             | `LogicalFalse`       |
-| single-node nodelist   | the node's JSON value | `LogicalTrue`        |
-| multiple-node nodelist | `Nothing`             | `LogicalTrue`        |
-{: #tbl-typeconv title="Conversion of nodelists to values and logicals"}
-
-For example, given a function `myfunc()` of declared result type
-`NodesType`, the following filter expressions are both valid but can
-have different and unexpected results:
-
-| function result        | `myfunc(@.a)` evaluation (as a test expression)                              | `myfunc(@.a)==42` evaluation (in a comparison)                                |
-| :-:                    | :-                                                                           | :-                                                                            |
-| empty nodelist         | The nodelist is converted to `LogicalFalse`.<br>The expression result is false. | The empty nodelist is converted to `Nothing`.<br>The expression result is false. |
-| single-node nodelist   | The nodelist is converted to `LogicalTrue`.<br>The expression result is true.   | The nodelist is converted to the node's value.<br>The expression result is true. |
-| multiple-node nodelist | The nodelist is converted to `LogicalTrue`.<br>The expression result is true.   | The nodelist is converted to `Nothing`.<br>The expression result is false.       |
+| fn(...) result         | `exist(fn(@..a))` evaluation (as a test expression) | `value(fn(@..a))==42` evaluation (in a comparison)             |
+| :-:                    | :-                                                  | :-                                                             |
+| empty nodelist         | `LogicalFalse`.<br>The test fails.                     | `Nothing`.<br>The expression result is false.                     |
+| single-node nodelist   | `LogicalTrue`.<br>The test succeeds.                   | The node's value.<br>The expression result is true if that is 42. |
+| multiple-node nodelist | `LogicalTrue`.<br>The test succeeds.                   | `Nothing`.<br>The expression result is false.                     |
+{: #tab-exist-value title="Using a function returning a `NodesType` in
+test expressions and comparisons"}
 
 Note that a multiple-node nodelist result is deemed `LogicalTrue` in
-the test expression, but cannot be used for conversion to a single
-value and thus feeds a comparison with `Nothing`.
+the test expression, but cannot be used for obtaining a single
+value and thus feeds the comparison expression with `Nothing`.
+
+
+### `exist` Function Extension {#exist-fn}
+
+Parameters:
+: 1. `NodesType`
+
+Result:
+: `LogicalType`
+
+The "exist" function extension returns `LogicalTrue` if the nodelist
+given consists of at least one node, `LogicalFalse` otherwise:
+
+~~~ JSONPath
+$[?exist(fn(@.*.price))]
+~~~
+
+The effect of the `exist` function is similar to the existence test
+that is performed when a query expression is directly used in a test
+expression:
+If the nodelist contains one or more nodes, the result is
+`LogicalTrue`.
+If the nodelist is empty, the result is `LogicalFalse`.
+
+
+### `value` Function Extension {#value-fn}
+
+Parameters:
+: 1. `NodesType`
+
+Result:
+: `ValueType`
+
+The "value" function extension provides a way to obtain the value of a
+node in a single-element nodelist and make that available for further
+processing in the filter expression:
+
+~~~ JSONPath
+$[?value(fn(@.*.price)) >= 7.99]
+~~~
+
+Its only argument is a nodelist.
+If the nodelist contains a single node, the result is the value of the node.
+If the nodelist is empty or contains multiple nodes, the result is `Nothing`.
+
+The effect of the `value` function is similar to the extraction of a
+node value that is performed when a query expression is used as either
+side of a comparison operator.  These query expressions, however, are
+syntactically limited to singular paths.  Here, the argument might be
+a nodelist with multiple nodes: it would be confusing to notate
+queries such as `fn(@..a) == fn(@..b)` without explicit indication
+that an extraction of a single value takes place at either side.
 
 
 ### `length` Function Extension {#length}
@@ -1679,9 +1711,9 @@ substring exists and `LogicalFalse` otherwise.
 | `$[?length(@.*) < 3]` | not well-typed since `@.*` is a non-singular path |
 | `$[?count(@.*) == 1]` | well-typed |
 | `$[?count(1) == 1]` | not well-typed since `1` is not a path  |
-| `$[?count(foo(@.*)) == 1]` | well-typed, where `foo` is a function extension with a parameter of type `NodesType` and result type `NodesType` |
+| `$[?count(fn(@.*)) == 1]`  | well-typed, where `fn` is a function extension with a parameter of type `NodesType` and result type `NodesType` |
 | `$[?match(@.timezone, 'Europe/.*')]`         | well-typed |
-| `$[?match(@.timezone, 'Europe/.*') == true]` | not well-typed as JSONPath logicals may not be used in comparisons |
+| `$[?match(@.timezone, 'Europe/.*') == true]` | not well-typed as `LogicalType` may not be used in comparisons |
 {: title="Function expression examples"}
 
 ## Segments  {#segments-details}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1275,8 +1275,8 @@ The comparison operators `==` and `<` are defined first and then these are used 
 
 When a path or function expression resulting in an empty nodelist appears on either side of a comparison:
 
-* a comparison using the operator `==` yields true if and only if the comparison
-is between two `comparable`s, each of which is a path or a function expression, and each of which result in an empty nodelist.
+* a comparison using the operator `==` yields true if and only if
+a path or a function expression resulting in an empty nodelist also appears on the other side of the comparison.
 
 * a comparison using the operator `<` yields false.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1457,7 +1457,7 @@ literal (which yields a `ValueType`), or a function expression (which
 yields the declared type of the function named).
 
 According to {{filter-selector}}, a `function-expr` is valid as part of
-a test expression (if the declared type is `NodesType`) or as a
+a test expression (if the declared type is `LogicalType`) or as a
 `comparable` (if the declared type is `ValueType`).
 
 Any function expressions in a query must be well-formed (by conforming to the above ABNF)
@@ -1520,10 +1520,9 @@ A function expression is well-typed if all of the following are true:
 * Each argument of the function can be used for the declared type of the corresponding declared
   parameter according to one of the following rules:
    * The argument is a function expression with declared result type that is the same as the declared type of the parameter.
-   * The argument is a literal primitive value and the defined type of the parameter is `ValueType`.
+   * The argument is a literal primitive value and the declared type of the parameter is `ValueType`.
    * The argument is a Singular Path or `filter-path` (which includes
-     Singular Paths), or a function expression with declared result
-     type `NodesType`.
+     Singular Paths) and the declared type of the parameter is `NodesType`.
 
 {{tab-exist-value}} summarizes how the two conversion functions can be
 used to make use of functions returning nodelists, using a
@@ -1543,8 +1542,8 @@ also be used in example further below.)
 test expressions and comparisons"}
 
 Note that a multiple-node nodelist result is deemed `LogicalTrue` in
-the test expression, but cannot be used for obtaining a single
-value and thus feeds the comparison expression with `Nothing`.
+a test expression, but cannot be used for obtaining a single
+value and thus feeds a comparison expression with `Nothing`.
 
 
 ### `exist` Function Extension {#exist-fn}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1537,6 +1537,12 @@ A function expression is well-typed if all of the following are true:
      * a function with declared type of `SingleNodeType` or `NodesType`
      * a `filter-path`
 
+### Processing Nodelists as Arguments
+
+When any `singular-path` or function expression with declared type of `SingleNodeType` appears as an argument for a parameter of type `ValueType`, each such path or function expression is replaced by the value of its node or `Nothing` if it is empty.
+
+When any `filter-path` or function expression with declared type of `SingleNodeType` or `NodesType` appears as an argument for a parameter of type `LogicalType`, each such path or function expression is replaced by `LogicalTrue` if the resulting nodelist contains any nodes and `LogicalFalse` if the resulting nodelist is empty.
+
 ### `length` Function Extension {#length}
 
 Parameters:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1500,6 +1500,8 @@ Notes:
 * `NodesType` is an abstraction of a `filter-path` (which appears
   in a test expression or as a function argument).
   Members of `NodesType` have no direct syntactical representation in JSONPath.
+* `SingleNodeType` is a subtype of `NodesType`. An instance of `SingleNodeType` is well-typed
+  wherever an instance of `NodesType` is well-typed.
 
 The abstract instances above can be obtained from the concrete representations in {{tbl-typerep}}.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1276,7 +1276,7 @@ The comparison operators `==` and `<` are defined first and then these are used 
 When a path or function expression resulting in an empty nodelist appears on either side of a comparison:
 
 * a comparison using the operator `==` yields true if and only if the comparison
-is between two paths or function expressions each of which result in an empty nodelist.
+is between two expressions, each of which is a path or a function expression, and each of which result in an empty nodelist.
 
 * a comparison using the operator `<` yields false.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1522,10 +1522,10 @@ A function expression is well-typed if all of the following are true:
   to have a result type of `LogicalType`, `SingleNodeType`, or `NodesType`.
 * If it occurs directly as a `comparable` in a comparison, the
   function is declared to have a result type of `ValueType` or `SingleNodeType`.
-* Otherwise, it is occurring as an argument to a further function
-  expression, and the following rules for function arguments apply to
+* If it occurs as an argument to a further function
+  expression, the following rules for function arguments apply to
   its declared result type.
-* Each argument of the function can be used for the declared type of the corresponding declared
+* Each argument of the function conforms to the declared type of the corresponding declared
   parameter according to one of the following rules:
    * The argument is a function expression with declared result type that is the same as,
      or a subtype of, the declared type of the parameter.


### PR DESCRIPTION
Builds on #412.  Attempts to address [this comment](https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/pull/412#discussion_r1120934952) from @cabo:

> There are 16 combinations. 5 of them are explained. You need functions like exist() and value() to make a few more work.

Only valid/well-formed scenarios are explained; others are considered invalid/poorly-formed.