### PR TITLE
Motivate the term "JSONPath"

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -326,6 +326,9 @@ go with a "consensus" between implementations even if it is rough, as
 long as that does not jeopardize the objective of obtaining a usable,
 stable JSON query language.
 
+The term _JSONPath_ was chosen because of the XPath inspiration and also because
+the outcome of a query consists of _paths_ identifying nodes in the JSON argument.
+
 ## JSON Values
 
 The JSON value a JSONPath query is applied to is, by definition, a


### PR DESCRIPTION
PR #424 changed the spec to use "path" only for paths, and "query" for queries. The term "JSONPath" is then left in need of some motivation. This is provided in the History section so as not to interfere with the normative text.