### PR TITLE
Clarify that JSONPath queries are sequences of Unicode scalar values.

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -274,7 +274,7 @@ Normalized Path:
 Unicode Scalar Value:
 : Any Unicode {{UNICODE}} code point except high-surrogate and low-surrogate code points.
   In other words, integers in either of the inclusive base 16 ranges 0 to D7FF and
-  E000 to 10FFFF. JSON string values are sequences of Unicode scalar values.
+  E000 to 10FFFF.  Both JSON string values and JSONPath queries are sequences of Unicode scalar values.
 
 Singular Query:
 : A JSONPath expression built from segments each of which, regardless of the input value,


### PR DESCRIPTION
(See discussion over in https://github.com/ietf-wg-jsonpath/iregexp/pull/23 )