### PR TITLE
Require function names to be registered

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1502,8 +1502,9 @@ The well-typedness of function expressions can now be defined in terms of this t
 
 For a function expression to be well typed:
 
-1. its declared type must be well typed in the context in which it occurs, and
-2. its arguments must be well typed for the declared type of the corresponding parameters.
+1. its function name must be registered (see {{iana-fnex}}),
+2. its declared type must be well typed in the context in which it occurs, and
+3. its arguments must be well typed for the declared type of the corresponding parameters.
 
 (1) As per the grammar, a function expression can occur in three different
 immediate contexts, which lead to the following conditions for well-typedness:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1510,7 +1510,8 @@ For a function expression to be well typed:
 parameter types of a function extension.
 
 Although a function expression being treated as well typed implies its function name is registered,
-the reverse is not necessarily true. Implementations must support the function extensions defined
+an implementation need not treat all registered functions as well typed.
+Implementations must support the function extensions defined
 in this document, but are free to support or not support other registered function extensions.
 
 If an implementation does not support a function extension used in a query, it should treat the

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1454,17 +1454,16 @@ Implementations MUST support the function extensions defined
 in this document, but are free to support or not support other registered function extensions.
 
 Implementations MUST NOT support function extensions that are not registered.
-Note: if an implementation supports a function extension that is not registered,
-the implementation will not conform to this specification until the function extension is
+
+Notes:
+
+* If an implementation supports a function extension that is not registered,
+the implementation will not conform to this specification unless or until the function extension is
 registered.
-To support a new function extension in an implementation, it is recommended that
-the implementation behaves by default in a "strict" mode that conforms to this specification and
-provides some way of behaving in a "non-strict" mode that supports the new function extension.
+* An implementation may behave by default in a "strict" mode that conforms to this specification
+and offer some way of behaving in a "non-strict" mode that supports unregistered function extensions.
 This ensures that the default behaviour of the implementation does not mislead users into
-thinking that the function extension is interoperable.
-To use the function extension successfully, users have to consciously choose to use non-strict mode.
-If the function extension is later registered, the implementation can then support the
-function extension in the default, strict mode.
+thinking that uregistered function extensions can be used interoperably.
 
 To define which function expressions are well typed,
 a type system is first introduced.

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1509,13 +1509,15 @@ For a function expression to be well typed:
 (1) The registered set of function extensions is the source of knowledge regarding the declared return and
 parameter types of a function extension.
 
-Although a function expression being treated as well typed implies its function name is registered,
-an implementation need not treat all registered functions as well typed.
+If a function expression is treated as well typed, the function extensions involved in the expression belong
+to the registered set.
+However, an implementation may treat a function expression as not well typed even if all the function extensions
+involved in the expression are registered.
 Implementations MUST support the function extensions defined
 in this document, but are free to support or not support other registered function extensions.
 
-If an implementation does not support a function extension used in a query, it MUST treat the
-function extension as not well typed.
+If an implementation does not support a function extension used in a query, it MUST treat
+any function expression involving the function extension as not well typed.
 
 (2) As per the grammar, a function expression can occur in three different
 immediate contexts, which lead to the following conditions for well-typedness:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1502,7 +1502,7 @@ The well-typedness of function expressions can now be defined in terms of this t
 
 For a function expression to be well typed:
 
-1. its function name must be registered (see {{iana-fnex}}),
+1. its function name MUST be registered (see {{iana-fnex}}),
 2. its declared type must be well typed in the context in which it occurs, and
 3. its arguments must be well typed for the declared type of the corresponding parameters.
 
@@ -1511,10 +1511,10 @@ parameter types of a function extension.
 
 Although a function expression being treated as well typed implies its function name is registered,
 an implementation need not treat all registered functions as well typed.
-Implementations must support the function extensions defined
+Implementations MUST support the function extensions defined
 in this document, but are free to support or not support other registered function extensions.
 
-If an implementation does not support a function extension used in a query, it should treat the
+If an implementation does not support a function extension used in a query, it MUST treat the
 function extension as not well typed.
 
 (2) As per the grammar, a function expression can occur in three different

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1506,7 +1506,17 @@ For a function expression to be well typed:
 2. its declared type must be well typed in the context in which it occurs, and
 3. its arguments must be well typed for the declared type of the corresponding parameters.
 
-(1) As per the grammar, a function expression can occur in three different
+(1) The registered set of function extensions is the source of knowledge regarding the return and
+parameter types of a function extension.
+
+Although a function expression being treated as well typed implies its function name is registered,
+the reverse is not necessarily true. Implementations must support the function extensions defined
+in this document, but are free to support or not support other registered function extensions.
+
+If an implementation does not support a function extension used in a query, it should treat the
+function extension as not well typed.
+
+(2) As per the grammar, a function expression can occur in three different
 immediate contexts, which lead to the following conditions for well-typedness:
 
 {:vspace}
@@ -1521,7 +1531,7 @@ As a `function-argument` in another function expression:
 : The function's declared result type fulfills the following rules for
   the corresponding parameter of the enclosing function.
 
-(2) The arguments of the function expression are well typed when
+(3) The arguments of the function expression are well typed when
 each argument of the function can be used for the declared type of the
 corresponding parameter, according to one of the following
 conditions:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1449,11 +1449,11 @@ otherwise the JSONPath implementation MUST raise an error
 (see {{synsem-overview}}).
 
 For a function expression to be supported, each function name in the expression
-MUST be registered (see {{iana-fnex}}).
+must be supported.
 Implementations MUST support the function extensions defined
 in this document, but are free to support or not support other registered function extensions.
 
-To define which supported function expressions are well typed,
+To define which function expressions are well typed,
 a type system is first introduced.
 
 ### Type System for Function Expressions {#typesys}

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1451,7 +1451,7 @@ otherwise the JSONPath implementation MUST raise an error
 For a function expression to be supported, each function extension involved in the expression
 must be supported.
 Implementations MUST support the function extensions defined
-in this document and SHOULD support all other registered function extensions.
+in this document, but are free to support or not support other registered function extensions.
 
 To define which function expressions are well typed,
 a type system is first introduced.

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -525,7 +525,7 @@ to the JSONPath processing (e.g., index values and steps) MUST be
 within the range of exact values defined in I-JSON {{-i-json}}, namely
 within the interval \[-(2<sup>53</sup>)+1, (2<sup>53</sup>)-1].
 
-2. Uses of function extensions must be *well typed*,
+2. Uses of function extensions must be *supported* and *well typed*,
 as described in {{fnex}}.
 
 A JSONPath implementation MUST raise an error for any query which is not
@@ -1443,16 +1443,25 @@ function-argument   = literal /
                       function-expr
 ~~~
 
-Any function expressions in a query must be well formed (by conforming to the above ABNF)
-and well typed,
+Any function expressions in a query must be well formed (by conforming to the above ABNF),
+supported, and well typed,
 otherwise the JSONPath implementation MUST raise an error
 (see {{synsem-overview}}).
-To define which function expressions are well typed,
+
+For a function expression to be supported, each function name in the expression
+MUST be registered (see {{iana-fnex}}).
+Implementations MUST support the function extensions defined
+in this document, but are free to support or not support other registered function extensions.
+
+To define which supported function expressions are well typed,
 a type system is first introduced.
 
 ### Type System for Function Expressions {#typesys}
 
 Each parameter as well as the result of a function extension must have a declared type.
+
+The registered set of function extensions (see {{iana-fnex}}) is the source of knowledge
+regarding the declared return and parameter types of a function extension.
 
 Declared types enable checking a JSONPath query for well-typedness
 independent of any query argument the JSONPath query is applied to.
@@ -1502,24 +1511,10 @@ The well-typedness of function expressions can now be defined in terms of this t
 
 For a function expression to be well typed:
 
-1. its function name MUST be registered (see {{iana-fnex}}),
-2. its declared type must be well typed in the context in which it occurs, and
-3. its arguments must be well typed for the declared type of the corresponding parameters.
+1. its declared type must be well typed in the context in which it occurs, and
+2. its arguments must be well typed for the declared type of the corresponding parameters.
 
-(1) The registered set of function extensions is the source of knowledge regarding the declared return and
-parameter types of a function extension.
-
-If a function expression is treated as well typed, the function extensions involved in the expression belong
-to the registered set.
-However, an implementation may treat a function expression as not well typed even if all the function extensions
-involved in the expression are registered.
-Implementations MUST support the function extensions defined
-in this document, but are free to support or not support other registered function extensions.
-
-If an implementation does not support a function extension used in a query, it MUST treat
-any function expression involving the function extension as not well typed.
-
-(2) As per the grammar, a function expression can occur in three different
+(1) As per the grammar, a function expression can occur in three different
 immediate contexts, which lead to the following conditions for well-typedness:
 
 {:vspace}
@@ -1534,7 +1529,7 @@ As a `function-argument` in another function expression:
 : The function's declared result type fulfills the following rules for
   the corresponding parameter of the enclosing function.
 
-(3) The arguments of the function expression are well typed when
+(2) The arguments of the function expression are well typed when
 each argument of the function can be used for the declared type of the
 corresponding parameter, according to one of the following
 conditions:

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1506,7 +1506,7 @@ For a function expression to be well typed:
 2. its declared type must be well typed in the context in which it occurs, and
 3. its arguments must be well typed for the declared type of the corresponding parameters.
 
-(1) The registered set of function extensions is the source of knowledge regarding the return and
+(1) The registered set of function extensions is the source of knowledge regarding the declared return and
 parameter types of a function extension.
 
 Although a function expression being treated as well typed implies its function name is registered,

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1448,10 +1448,10 @@ supported, and well typed,
 otherwise the JSONPath implementation MUST raise an error
 (see {{synsem-overview}}).
 
-For a function expression to be supported, each function name in the expression
+For a function expression to be supported, each function extension involved in the expression
 must be supported.
 Implementations MUST support the function extensions defined
-in this document, but are free to support or not support other registered function extensions.
+in this document and SHOULD support all other registered function extensions.
 
 To define which function expressions are well typed,
 a type system is first introduced.

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1455,11 +1455,6 @@ in this document, but are free to support or not support other registered functi
 
 Implementations MUST NOT support function extensions that are not registered.
 
-Note: an implementation may behave by default in a "strict" mode that conforms to this specification
-and offer some way of behaving in a "non-strict" mode that supports unregistered function extensions.
-This ensures that the default behaviour of the implementation does not mislead users into
-thinking that uregistered function extensions can be used interoperably.
-
 To define which function expressions are well typed,
 a type system is first introduced.
 

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1455,12 +1455,7 @@ in this document, but are free to support or not support other registered functi
 
 Implementations MUST NOT support function extensions that are not registered.
 
-Notes:
-
-* If an implementation supports a function extension that is not registered,
-the implementation will not conform to this specification unless or until the function extension is
-registered.
-* An implementation may behave by default in a "strict" mode that conforms to this specification
+Note: an implementation may behave by default in a "strict" mode that conforms to this specification
 and offer some way of behaving in a "non-strict" mode that supports unregistered function extensions.
 This ensures that the default behaviour of the implementation does not mislead users into
 thinking that uregistered function extensions can be used interoperably.

--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1453,6 +1453,19 @@ must be supported.
 Implementations MUST support the function extensions defined
 in this document, but are free to support or not support other registered function extensions.
 
+Implementations MUST NOT support function extensions that are not registered.
+Note: if an implementation supports a function extension that is not registered,
+the implementation will not conform to this specification until the function extension is
+registered.
+To support a new function extension in an implementation, it is recommended that
+the implementation behaves by default in a "strict" mode that conforms to this specification and
+provides some way of behaving in a "non-strict" mode that supports the new function extension.
+This ensures that the default behaviour of the implementation does not mislead users into
+thinking that the function extension is interoperable.
+To use the function extension successfully, users have to consciously choose to use non-strict mode.
+If the function extension is later registered, the implementation can then support the
+function extension in the default, strict mode.
+
 To define which function expressions are well typed,
 a type system is first introduced.
 


### PR DESCRIPTION
Without this change, it is not very clear what happens when an unregistered function name is used.