### PR TITLE
JSON strings are unfortunately not sequences of scalar values.

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -270,7 +270,7 @@ Normalized Path:
 Unicode Scalar Value:
 : Any Unicode {{UNICODE}} code point except high-surrogate and low-surrogate code points.
   In other words, integers in either of the inclusive base 16 ranges 0 to D7FF and
-  E000 to 10FFFF.  Both JSON string values and JSONPath queries are sequences of Unicode scalar values.
+  E000 to 10FFFF. JSONPath queries are sequences of Unicode scalar values.
 
 Segment:
 : One of the constructs which select children (`[<selectors>]`)


### PR DESCRIPTION
 Section 1.3 covers this hazard. This should fix #473.