### PR TITLE
Rob Wilton #3: clarify "are not ordered" in filter examples

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -1388,16 +1388,16 @@ Comparisons:
 | `$.arr != $.arr` | false | Array comparison |
 | `$.obj == 17` | false | Type mismatch |
 | `$.obj != 17` | true | Type mismatch |
-| `$.obj <= $.arr` | false | Objects and arrays are not ordered |
-| `$.obj < $.arr` | false | Objects and arrays are not ordered |
+| `$.obj <= $.arr` | false | Objects and arrays do not offer `<` comparison |
+| `$.obj < $.arr`  | false | Objects and arrays do not offer `<` comparison |
 | `$.obj <= $.obj` | true | `==` implies `<=` |
 | `$.arr <= $.arr` | true | `==` implies `<=` |
-| `1 <= $.arr` | false | Arrays are not ordered |
-| `1 >= $.arr` | false | Arrays are not ordered |
-| `1 > $.arr` | false | Arrays are not ordered |
-| `1 < $.arr` | false | Arrays are not ordered |
+| `1 <= $.arr` | false | Arrays do not offer `<` comparison |
+| `1 >= $.arr` | false | Arrays do not offer `<` comparison |
+| `1 > $.arr` | false | Arrays do not offer `<` comparison |
+| `1 < $.arr` | false | Arrays do not offer `<` comparison |
 | `true <= true` | true | `==` implies `<=` |
-| `true > true` | false | Booleans are not ordered |
+| `true > true` | false | Booleans do not offer `<` comparison |
 {: #tbl-comparison title="Comparison examples" }
 
 The second set of examples shows some complete JSONPath queries that make use


### PR DESCRIPTION
→ do not offer `<` comparison
