### PR TITLE
Rob Wilton #1: clarify luxury overflow

### DIFF
--- a/draft-ietf-jsonpath-base.md
+++ b/draft-ietf-jsonpath-base.md
@@ -564,9 +564,10 @@ Obviously, an implementation can still fail when executing a JSONPath
 query, e.g., because of resource depletion, but this is not modeled in
 this document.  However, the implementation MUST NOT
 silently malfunction.  Specifically, if a valid JSONPath query is
-evaluated against a structured value whose size does not fit in the
-range of exact values, interfering with the correct interpretation of
-the query, the implementation MUST provide an indication of overflow.
+evaluated against a structured value whose size is too large to
+process the query correctly (for instance requiring the processing of
+numbers that fall outside the range of exact values), the implementation
+MUST provide an indication of overflow.
 
 (Readers familiar with the HTTP error model may be reminded of 400
 type errors when pondering well-formedness and validity, while


### PR DESCRIPTION
The specific case addressed here is about JSON values large enough so you no longer can evaluate, e.g., [?length(@) < length($.a)], in exact numbers. This is a bit of a luxury problem, as 2**53 bytes ⩰ 9 Petabytes. Backblaze reports they can [store a Petabyte for some $35000][1], so this is not an entirely hypothetical case any more, and will get less so during the time the spec lasts.

[1]: https://www.backblaze.com/blog/petabytes-on-a-budget-10-years-and-counting/